### PR TITLE
Fix: Election officer permissions

### DIFF
--- a/config/install/user.role.localgov_elections_officer.yml
+++ b/config/install/user.role.localgov_elections_officer.yml
@@ -22,6 +22,7 @@ permissions:
   - 'access content overview'
   - 'access taxonomy overview'
   - 'access toolbar'
+  - 'can fetch boundaries'
   - 'create localgov_area_vote content'
   - 'create localgov_election content'
   - 'create terms in localgov_party'


### PR DESCRIPTION
Election officer should be able to create Areas i.e. should be able to fetch boundary data.

### Reproduction steps
- Login as an Election officer.
- Open the "Add areas" tab of an existing election from /node/NODE-ID/boundary-fetch
- Rather than listing the boundary sources, it simply says `The page you are looking for is no longer available. The information may have been removed as it was out of date.`