### PR TITLE
removes dependency on Font Awesome

### DIFF
--- a/config/install/views.view.localgov_electoral_candidates.yml
+++ b/config/install/views.view.localgov_electoral_candidates.yml
@@ -104,7 +104,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: "{% if localgov_election_cand_file %}\r\n<a href='{{ localgov_election_cand_file }}'><i class=\"fa-solid fa-file-pdf\"></i>{{localgov_election_area_name}}</a>\r\n{% else %}\r\n{{ localgov_election_area_name }}\r\n{% endif %}\r\n"
+            text: "{% if localgov_election_cand_file %}\r\n<a href='{{ localgov_election_cand_file }}'>{{localgov_election_area_name}}</a>\r\n{% else %}\r\n{{ localgov_election_area_name }}\r\n{% endif %}\r\n"
             make_link: false
             path: ''
             absolute: false

--- a/css/election-menu.css
+++ b/css/election-menu.css
@@ -29,6 +29,13 @@
   color: white;
 }
 
+.election-menu__list-icon {
+  width: .75rem;
+}
+.election-menu__list-item.active .election-menu__list-icon path {
+  fill: white;
+}
+
 .election-menu-block__button-container {
   display: flex;
   justify-content: end;

--- a/localgov_elections.libraries.yml
+++ b/localgov_elections.libraries.yml
@@ -19,7 +19,6 @@ electoral_candidates_view:
     theme:
       css/variables.css: { }
       css/electoral-candidates-view.css: { }
-      'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.1/css/all.min.css': { type: external,  minified: true }
 
 division_results:
   version: 1.x
@@ -68,11 +67,9 @@ party_colours:
     - core/once
 
 election_menu:
-  version: 1.x
   css:
     theme:
       css/election-menu.css: { }
-      'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.1/css/all.min.css': { type: external,  minified: true }
   js:
     js/election-menu.js: {}
   dependencies:

--- a/templates/election-menu.html.twig
+++ b/templates/election-menu.html.twig
@@ -2,7 +2,12 @@
   {% if links %}
     <ul class="election-menu__list">
     {% for link in links %}
-      <li {{ link.attributes.addClass('election-menu__list-item') }}>{{ link.link }} <i class="fa-solid fa-chevron-right"></i></li>
+      <li {{ link.attributes.addClass('election-menu__list-item') }}>
+        {{ link.link }}
+        <span class="election-menu__list-icon">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><!--!Font Awesome Free 6.5.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"/></svg>
+        </span>
+      </li>
     {% endfor %}
     </ul>
   {% endif %}


### PR DESCRIPTION
Closes #14 

Note, this PR:

1. Adds the SVG inline for the menu, but
2. Removes the icon from the PDF upload field in the view as we cannot inline SVGs in the rewrite field for a view. If we _really_ want this icon, I suggest we create a follow up issue.

===
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.