### PR TITLE
Fix: Results heading on the Summary page

### DIFF
--- a/config/install/views.view.localgov_election_results.yml
+++ b/config/install/views.view.localgov_election_results.yml
@@ -1365,17 +1365,11 @@ display:
       group_by: false
       display_description: ''
       header:
-        area_text_custom:
-          id: area_text_custom
+        area_election_results_heading:
+          id: area_election_results_heading
           table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: text_custom
-          empty: false
-          content: "<div>\r\n<h2>Ward results</h2>\r\n</div>"
-          tokenize: false
+          field: area_election_results_heading
+          plugin_id: localgov_elections_results_heading
       display_extenders: {  }
     cache_metadata:
       max-age: -1

--- a/localgov_elections.module
+++ b/localgov_elections.module
@@ -32,6 +32,11 @@ function localgov_elections_theme($existing, $type, $theme, $path) {
         'links' => NULL,
       ],
     ],
+    'localgov_elections_results_heading' => [
+      'variables' => [
+        'election_type' => '',
+      ],
+    ],
   ];
 }
 
@@ -209,6 +214,13 @@ function localgov_elections_views_data_alter(array &$data) {
     ],
     'filter' => [
       'id' => 'standard',
+    ],
+  ];
+  $data['views']['area_election_results_heading'] = [
+    'title' => t('Election results heading'),
+    'help' => t('Sets dynamic heading depending on election type.'),
+    'area' => [
+      'id' => 'localgov_elections_results_heading',
     ],
   ];
 }

--- a/src/Plugin/views/area/ResultsHeading.php
+++ b/src/Plugin/views/area/ResultsHeading.php
@@ -23,6 +23,10 @@ class ResultsHeading extends AreaPluginBase {
    */
   public function render($empty = FALSE) {
 
+    if ($empty && empty($this->options['empty'])) {
+      return [];
+    }
+
     $election_node_id = current($this->view->args);
     $election_node    = $this->entityTypeManager->getStorage('node')->load($election_node_id);
 
@@ -36,6 +40,10 @@ class ResultsHeading extends AreaPluginBase {
 
     $election_type = $election_node->localgov_election_type->first();
     $election_type_label = $election_type ? $election_type->view() : '';
+
+    // Covers special cases.
+    $election_type_value = $election_node->localgov_election_type->getString();
+    $election_type_label = self::LABEL_MAPPING[$election_type_value] ?? $election_type_label;
 
     return [
       '#theme'         => 'localgov_elections_results_heading',
@@ -61,5 +69,14 @@ class ResultsHeading extends AreaPluginBase {
       $container->get('entity_type.manager'),
     );
   }
+
+  /**
+   * Some labels are better when overwritten.
+   *
+   * Mapping between overridden Election type values and labels.
+   */
+  const LABEL_MAPPING = [
+    'NationalParliamentary' => 'Constituency',
+  ];
 
 }

--- a/src/Plugin/views/area/ResultsHeading.php
+++ b/src/Plugin/views/area/ResultsHeading.php
@@ -46,10 +46,8 @@ class ResultsHeading extends AreaPluginBase {
   /**
    * Constructs a new plugin instance.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, protected EntityTypeManagerInterface $entityTypeManager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-
-    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**

--- a/src/Plugin/views/area/ResultsHeading.php
+++ b/src/Plugin/views/area/ResultsHeading.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\localgov_elections\Plugin\views\area;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\node\NodeInterface;
+use Drupal\views\Plugin\views\area\AreaPluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Views area plugin for election results heading.
+ *
+ * Sets dynamic heading depending on election type.
+ *
+ * @ViewsArea("localgov_elections_results_heading")
+ */
+class ResultsHeading extends AreaPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render($empty = FALSE) {
+
+    $election_node_id = current($this->view->args);
+    $election_node    = $this->entityTypeManager->getStorage('node')->load($election_node_id);
+
+    if (!($election_node instanceof NodeInterface)) {
+      return [];
+    }
+
+    if (!$election_node->hasField('localgov_election_type')) {
+      return [];
+    }
+
+    $election_type = $election_node->localgov_election_type->first();
+    $election_type_label = $election_type ? $election_type->view() : '';
+
+    return [
+      '#theme'         => 'localgov_elections_results_heading',
+      '#election_type' => $election_type_label,
+    ];
+  }
+
+  /**
+   * Constructs a new plugin instance.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+    );
+  }
+
+}

--- a/templates/localgov-elections-results-heading.html.twig
+++ b/templates/localgov-elections-results-heading.html.twig
@@ -11,7 +11,8 @@
 #}
 
 {% if election_type %}
-  <h2 class="election-results-heading">{{ "%s results"|format(election_type)|t }}</h2>
+  {% set rendered_election_type = render_var(election_type) %}
+  <h2 class="election-results-heading">{{ "%s results"|format(rendered_election_type)|t }}</h2>
 {% else %}
   <h2 class="election-results-heading">{{ "Results"|t }}</h2>
 {% endif %}

--- a/templates/localgov-elections-results-heading.html.twig
+++ b/templates/localgov-elections-results-heading.html.twig
@@ -1,0 +1,19 @@
+{#
+/**
+ * @file
+ * Default template for the localgov_elections_results_heading theme.
+ *
+ * Sets dynamic heading depending on election type.
+ *
+ * Available variables:
+ * - election_type: National election or local election or something else?
+ */
+#}
+
+<div>
+  {% if election_type %}
+  <h2 class="election-results-heading">{{ election_type }} results</h2>
+  {% else %}
+  <h2 class="election-results-heading">Results</h2>
+  {% endif %}
+</div>

--- a/templates/localgov-elections-results-heading.html.twig
+++ b/templates/localgov-elections-results-heading.html.twig
@@ -10,10 +10,8 @@
  */
 #}
 
-<div>
-  {% if election_type %}
-  <h2 class="election-results-heading">{{ election_type }} results</h2>
-  {% else %}
-  <h2 class="election-results-heading">Results</h2>
-  {% endif %}
-</div>
+{% if election_type %}
+  <h2 class="election-results-heading">{{ "%s results"|format(election_type)|t }}</h2>
+{% else %}
+  <h2 class="election-results-heading">{{ "Results"|t }}</h2>
+{% endif %}

--- a/tests/src/Functional/ElectionSummaryTest.php
+++ b/tests/src/Functional/ElectionSummaryTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\localgov_elections\Functional;
+
+use Drupal\node\NodeInterface;
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Tests results heading text on the summary page.
+ *
+ * The results heading text differs based on election types.
+ *
+ * @group localgov_elections
+ */
+class ElectionSummaryTest extends BrowserTestBase {
+
+  /**
+   * Tests result heading text.
+   */
+  public function testResultHeadingOnSummaryPage() {
+
+    $election_page_url = $this->electionPage->toUrl();
+
+    foreach (static::EXPECTED_RESULT_HEADINGS as $election_type => $expected_result_heading_text) {
+      $this->electionPage->set('localgov_election_type', $election_type)->save();
+
+      $this->drupalGet($election_page_url);
+      $this->assertSession()->statusCodeEquals(200);
+      $this->assertSession()->pageTextContains($expected_result_heading_text);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * Sets up an Election page and attaches an Area to it.  No election type is
+   * set at this stage.
+   */
+  protected function setUp(): void {
+
+    parent::setUp();
+
+    $node_storage = $this->container->get('entity_type.manager')->getStorage('node');
+
+    $this->electionPage = $node_storage->create([
+      'title' => "UK Election 2024",
+      'status' => TRUE,
+      'type' => "localgov_election",
+    ]);
+    $this->electionPage->save();
+
+    $this->area = $node_storage->create([
+      'title'                           => "An area",
+      'status'                          => TRUE,
+      'type'                            => "localgov_area_vote",
+      'localgov_election'               => $this->electionPage->id(),
+      'localgov_election_votes_final'   => TRUE,
+      'localgov_election_boundary_data' => json_encode([
+        'type'        => 'Point',
+        'coordinates' => [1.234567, 2.345678],
+      ]),
+    ]);
+    $this->area->save();
+  }
+
+  /**
+   * Mapping between election types and their corresponding result headings.
+   *
+   * @see field.storage.node.localgov_election_type.yml
+   */
+  const EXPECTED_RESULT_HEADINGS = [
+    ''                      => 'Results',
+    'Parish'                => 'Parish results',
+    'DistrictAndBorough'    => 'District and Borough results',
+    'County'                => 'County results',
+    'Mayoral'               => 'Mayoral results',
+    'NationalParliamentary' => 'Constituency results',
+    'EuropeanParliamentary' => 'European Parliamentary results',
+  ];
+
+  /**
+   * Drupal theme used during test runs.
+   *
+   * @var string
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Modules to activate.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'localgov_elections',
+    'localgov_elections_uk_parties',
+  ];
+
+  /**
+   * An election node.
+   *
+   * @var Drupal\node\NodeInterface
+   */
+  protected NodeInterface $electionPage;
+
+  /**
+   * An Area node.
+   *
+   * @var Drupal\node\NodeInterface
+   */
+  protected NodeInterface $area;
+
+  /**
+   * {@inheritdoc}
+   */
+  // @codingStandardsIgnoreStart
+  protected $strictConfigSchema = FALSE;
+  // @codingStandardsIgnoreEnd
+
+}


### PR DESCRIPTION
Varies the results heading depending on the type of the election.

How to reproduce:
- Create a *National Parliamentary* election.
- Open the summary page of this new election.
- Look for the results.
- The results heading says "Ward results".

This change fixes the wording of the heading to say *National Parliamentary results*, *Parish results* and so on.

Resolves #72 