### PR TITLE
Show votes only when finalised

### DIFF
--- a/config/install/views.view.localgov_election_results.yml
+++ b/config/install/views.view.localgov_election_results.yml
@@ -1147,8 +1147,8 @@ display:
           label: Votes
           exclude: false
           alter:
-            alter_text: false
-            text: ''
+            alter_text: true
+            text: "{% if localgov_election_votes_final  == \"1\" %}\r\n{{ localgov_election_votes }} \r\n{% endif %}"
             make_link: false
             path: ''
             absolute: false

--- a/localgov_elections.install
+++ b/localgov_elections.install
@@ -47,7 +47,7 @@ function localgov_elections_uninstall($is_syncing) {
   }
 }
 
-/*
+/**
  * Update results view for already installed module
  */
 function localgov_elections_update_10001(&$sandbox) {

--- a/localgov_elections.install
+++ b/localgov_elections.install
@@ -46,3 +46,13 @@ function localgov_elections_uninstall($is_syncing) {
   catch (EntityStorageException $e) {
   }
 }
+
+function localgov_elections_update_10001(&$sandbox) {
+
+  $config_obj = \Drupal::configFactory()->getEditable('views.view.localgov_election_results');
+  $config_obj->set('display.block_3.display_options.fields.localgov_election_votes.alter.alter_text', TRUE);
+  $config_obj->set('display.block_3.display_options.fields.localgov_election_votes.alter.text', '{% if localgov_election_votes_final  == \"1\" %}\r\n{{ localgov_election_votes }} \r\n{% endif %}');
+  $config_obj->save();
+
+  Drupal::logger('localgov_elections')->notice("Updated results view");
+}

--- a/localgov_elections.install
+++ b/localgov_elections.install
@@ -47,6 +47,9 @@ function localgov_elections_uninstall($is_syncing) {
   }
 }
 
+/*
+ * Update results view for already installed module
+ */
 function localgov_elections_update_10001(&$sandbox) {
 
   $config_obj = \Drupal::configFactory()->getEditable('views.view.localgov_election_results');

--- a/localgov_elections.install
+++ b/localgov_elections.install
@@ -48,7 +48,7 @@ function localgov_elections_uninstall($is_syncing) {
 }
 
 /**
- * Update results view for already installed module
+ * Update results view for already installed module.
  */
 function localgov_elections_update_10001(&$sandbox) {
 


### PR DESCRIPTION
Enter some results, finalise the vote, save and then reverse the final vote, save, the votes will continue to show on Ward Results table on Summary page. This fixes it.