### PR TITLE
hides results timeline for national elections

### DIFF
--- a/src/Plugin/Block/ElectionmenuBlock.php
+++ b/src/Plugin/Block/ElectionmenuBlock.php
@@ -126,10 +126,14 @@ class ElectionmenuBlock extends BlockBase implements ContainerFactoryPluginInter
       ->accessCheck(FALSE)
       ->execute();
     if ($results) {
-      $urls[] = [
-        'attributes' => new Attribute(),
-        'link' => Link::fromTextAndUrl($this->t('Results timeline'), Url::fromRoute('view.localgov_election_results_timeline.page_1', ['node' => $this->node->id()])),
-      ];
+      // Hide share of the vote for national parliamentary elections as per:
+      // https://github.com/localgovdrupal/localgov_elections/issues/15
+      if ($node->get('localgov_election_type')?->value != "NationalParliamentary") {
+        $urls[] = [
+          'attributes' => new Attribute(),
+          'link' => Link::fromTextAndUrl($this->t('Results timeline'), Url::fromRoute('view.localgov_election_results_timeline.page_1', ['node' => $this->node->id()])),
+        ];
+      }
 
       // Hide share of the vote for national parliamentary elections as per:
       // https://github.com/localgovdrupal/localgov_elections/issues/57


### PR DESCRIPTION
Checks if we are on a national election, and, if so, doesn't show the results timeline, until we sort out exactly what we want from it (see #15)

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.