### PR TITLE
Add default opacity for colours of default UK parties.

### DIFF
--- a/modules/localgov_elections_uk_parties/localgov_elections_uk_parties.install
+++ b/modules/localgov_elections_uk_parties/localgov_elections_uk_parties.install
@@ -144,8 +144,8 @@ function localgov_elections_uk_parties_install() {
       'vid' => $parties_vocabulary,
       'localgov_election_party_uri' => $details['link'],
       'localgov_election_abbreviation' => $details['abbreviation'],
-      'localgov_election_party_colour' => $details['colour'],
-      'localgov_election_text_colour' => $details['text_colour'],
+      'localgov_election_party_colour' => ['color' => $details['colour'], 'opacity' => '1.0'],
+      'localgov_election_text_colour' => ['color' => $details['text_colour'], 'opacity' => '1.0'],
     ])->save();
   }
 }


### PR DESCRIPTION
See #89 

This should set the opacity to default to 1.0 for all the default colours.