### PR TITLE
Fix issue with demo content taxonomy names

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
             "drupal/social_post_twitter": {
                 "Fix API integration (see https://www.drupal.org/project/social_post_twitter/issues/3392216)": "https://www.drupal.org/files/issues/2023-10-13/twitter_fixes.patch",
                 "Fix WOD (see https://www.drupal.org/project/social_post_twitter/issues/3436436#comment-15522882)": "https://www.drupal.org/files/issues/2024-03-27/sdk-init-fix.patch"
+            },
+            "drupal/autocomplete_deluxe": {
+                "Fix Help text not displaying (see: https://www.drupal.org/project/autocomplete_deluxe/issues/3171362)": "https://www.drupal.org/files/issues/2021-12-01/3171362-fix-help-text-not-display-2_0.patch"
             }
         }
     }

--- a/config/install/field.field.paragraph.localgov_election_candidate.localgov_election_party.yml
+++ b/config/install/field.field.paragraph.localgov_election_candidate.localgov_election_party.yml
@@ -13,7 +13,7 @@ field_name: localgov_election_party
 entity_type: paragraph
 bundle: localgov_election_candidate
 label: Party
-description: 'Registered political party name (or leave as <em>Independent</em> for candidates with no political affiliation)'
+description: 'Registered political party name. Do not enter brackets in the party name.'
 required: true
 translatable: false
 default_value: ''

--- a/localgov_elections.module
+++ b/localgov_elections.module
@@ -863,6 +863,15 @@ function localgov_elections_form_node_localgov_area_vote_edit_form_alter(&$form,
 }
 
 /**
+ * Implements hook_form_BASE_FORM_ID_alter().
+ */
+function localgov_elections_form_taxonomy_term_localgov_party_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  if (isset($form["name"]["widget"][0]['value'])) {
+    $form["name"]["widget"][0]['value']["#description"] = t("The party name. Do not enter brackets in the party nameph.");
+  }
+}
+
+/**
  * Validation function for area vote node forms.
  */
 function localgov_elections_area_vote_form_validation($form, FormStateInterface $form_state) {

--- a/modules/localgov_elections_demo_content/content/taxonomy_term/017b30a5-ec34-4aba-a12e-612a5c43e661.yml
+++ b/modules/localgov_elections_demo_content/content/taxonomy_term/017b30a5-ec34-4aba-a12e-612a5c43e661.yml
@@ -10,7 +10,7 @@ default:
       value: true
   name:
     -
-      value: 'Conservative'
+      value: 'Conservative - demo content'
   weight:
     -
       value: 0

--- a/modules/localgov_elections_demo_content/content/taxonomy_term/017b30a5-ec34-4aba-a12e-612a5c43e661.yml
+++ b/modules/localgov_elections_demo_content/content/taxonomy_term/017b30a5-ec34-4aba-a12e-612a5c43e661.yml
@@ -10,7 +10,7 @@ default:
       value: true
   name:
     -
-      value: 'Conservative (demo content)'
+      value: 'Conservative'
   weight:
     -
       value: 0

--- a/modules/localgov_elections_demo_content/content/taxonomy_term/33c84934-7f19-47e7-a243-43f1a29e9d1f.yml
+++ b/modules/localgov_elections_demo_content/content/taxonomy_term/33c84934-7f19-47e7-a243-43f1a29e9d1f.yml
@@ -10,7 +10,7 @@ default:
       value: true
   name:
     -
-      value: 'Labour (demo content)'
+      value: 'Labour'
   weight:
     -
       value: 0

--- a/modules/localgov_elections_demo_content/content/taxonomy_term/33c84934-7f19-47e7-a243-43f1a29e9d1f.yml
+++ b/modules/localgov_elections_demo_content/content/taxonomy_term/33c84934-7f19-47e7-a243-43f1a29e9d1f.yml
@@ -10,7 +10,7 @@ default:
       value: true
   name:
     -
-      value: 'Labour'
+      value: 'Labour - demo content'
   weight:
     -
       value: 0

--- a/modules/localgov_elections_demo_content/content/taxonomy_term/8d045aee-e3b8-47c0-9273-054c6af9d417.yml
+++ b/modules/localgov_elections_demo_content/content/taxonomy_term/8d045aee-e3b8-47c0-9273-054c6af9d417.yml
@@ -10,7 +10,7 @@ default:
       value: true
   name:
     -
-      value: 'Liberal Democrats'
+      value: 'Liberal Democrats - demo content'
   weight:
     -
       value: 0

--- a/modules/localgov_elections_demo_content/content/taxonomy_term/8d045aee-e3b8-47c0-9273-054c6af9d417.yml
+++ b/modules/localgov_elections_demo_content/content/taxonomy_term/8d045aee-e3b8-47c0-9273-054c6af9d417.yml
@@ -10,7 +10,7 @@ default:
       value: true
   name:
     -
-      value: 'Liberal Democrats (demo content)'
+      value: 'Liberal Democrats'
   weight:
     -
       value: 0

--- a/modules/localgov_elections_demo_content/content/taxonomy_term/8d58c7a0-9201-4826-872a-8115a3f55535.yml
+++ b/modules/localgov_elections_demo_content/content/taxonomy_term/8d58c7a0-9201-4826-872a-8115a3f55535.yml
@@ -10,7 +10,7 @@ default:
       value: true
   name:
     -
-      value: 'Reform UK'
+      value: 'Reform UK - demo content'
   weight:
     -
       value: 0

--- a/modules/localgov_elections_demo_content/content/taxonomy_term/8d58c7a0-9201-4826-872a-8115a3f55535.yml
+++ b/modules/localgov_elections_demo_content/content/taxonomy_term/8d58c7a0-9201-4826-872a-8115a3f55535.yml
@@ -10,7 +10,7 @@ default:
       value: true
   name:
     -
-      value: 'Reform UK (demo content)'
+      value: 'Reform UK'
   weight:
     -
       value: 0

--- a/modules/localgov_elections_demo_content/content/taxonomy_term/b642d283-9860-4ac2-a584-7fb96b03f070.yml
+++ b/modules/localgov_elections_demo_content/content/taxonomy_term/b642d283-9860-4ac2-a584-7fb96b03f070.yml
@@ -10,7 +10,7 @@ default:
       value: true
   name:
     -
-      value: 'Green Party (demo content)'
+      value: 'Green Party'
   weight:
     -
       value: 0

--- a/modules/localgov_elections_demo_content/content/taxonomy_term/b642d283-9860-4ac2-a584-7fb96b03f070.yml
+++ b/modules/localgov_elections_demo_content/content/taxonomy_term/b642d283-9860-4ac2-a584-7fb96b03f070.yml
@@ -10,7 +10,7 @@ default:
       value: true
   name:
     -
-      value: 'Green Party'
+      value: 'Green Party - demo content'
   weight:
     -
       value: 0


### PR DESCRIPTION
Should close #91.

What this PR does:

1. Removes brackets from demo content party names
2. Adds warning to taxonomy page for party name in party taxonomy page
3. Adds warning to candidate party autocomplete field widget
4. Adds a patch so the help text appears on autocomplete deluxe widget