### PR TITLE
Prevent localgov_election_candidate paragraphs from generating new re…

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You may also wish to use the submodules provided as part of the Localgov Electio
 2. Localgov Elections Parliamentary Constituency Provider - Boundary source provider for Office of National Statistics 2024 constituency boundaries
 3. LocalGov Elections Reporting Social Post Integration - Post results to social media (Twitter/X)
 4. LocalGov Elections Reporting Demo - Demo content to help with testing/evaluation
-5. LocalGov Elections Reporting - UK Parties - Adds the majority of UK political parties to the party taxonomy. 
+5. LocalGov Elections Reporting - UK Parties - Adds the majority of UK political parties to the party taxonomy.
 
 Further details for these modules are in their own module READMEs and the [Documentation](docs/index.md).
 
@@ -49,15 +49,23 @@ at https://github.com/localgovdrupal/localgov_elections/issues
 ### Known issues
 
 #### Node Revisions
-We know there is currently an issue with using node revisions with area votes. If you
-use revisions with area votes, the results might not appear correctly. We are tracking this in
-issue [#94](https://github.com/localgovdrupal/localgov_elections/issues/94). For the time being, we
-suggest not using revisions with area vote nodes or the election nodes. 
-If you have Localgov Workflows turned on, disable this functionality from the area vote nodes and the
-election nodes.
 
-If you are experiencing this already you can fix the issue by turning revisions off and saving
-the affected nodes manually. This should make the results appear normally again.
+Revisions do not currently work with the 'Areas vote' content type.
+We have implemented a work around to mitigate the situation by preventing
+the creation of revisions for the candidate paragraph entities.
+
+We are tracking this in issue
+[#94](https://github.com/localgovdrupal/localgov_elections/issues/94).
+
+For the time being, we suggest not using attempting to use revisions with
+'Areas vote' nodes.
+
+If you have Localgov Workflows turned on, it will enable 'Create new revision'
+by default. This should not be a cause for concern, as the problematic candidate
+paragraphs are being forced to ignore revisions.
+
+If you have any questions or problems, please ask in the #feature_elections
+channel in the LocalGov Drupal Slack channel.
 
 ## Maintainers
 
@@ -65,5 +73,6 @@ This project is currently maintained by:
 
 - Chris Wales https://github.com/chriswales95
 - Duncan Davidson https://github.com/dedavidson
+- Finn Lewis: https://www.drupal.org/u/finn-lewis
 
 It is based on work originally done by Rob Carr https://github.com/rgcarr.

--- a/localgov_elections.module
+++ b/localgov_elections.module
@@ -83,6 +83,16 @@ function localgov_elections_entity_presave(EntityInterface $entity) {
       }
     }
   }
+
+  if ($entity->getEntityTypeId() == 'paragraph' && $entity->getType() == 'localgov_election_candidate') {
+    // We are referencing two instances of the same paragraph, the winning
+    // localgov_election_candidate. When 'create new revision' is checked, this
+    // seems to attempt to create two new revisions and the original entity
+    // reference from the candidates field is broken.
+    // To mitifate this we can force the paragraph NOT to create a new revision.
+    $entity->setNewRevision(FALSE);
+  }
+
 }
 
 /**


### PR DESCRIPTION
…visions.

See #94 

Please test this! 

Steps to reproduce the original bug: 

https://github.com/localgovdrupal/localgov_elections/issues/94#issuecomment-2206127506

With this small change, localgov_election_candidate paragraphs should not generate new revisions, so the duplicate revision creation is averted.

This mitigates the bug and prevents random data displaying, but still means revisions does not work.

