### PR TITLE
adds better spacing for election overview

### DIFF
--- a/css/election-results.css
+++ b/css/election-results.css
@@ -1,3 +1,10 @@
+.localgov-election__content > * + * {
+  margin-top: 3rem;
+  padding-top: 3rem;
+  border-top: var(--table-border);
+}
+
+
 .county-summary__subheading {
   padding: 1rem;
   background-color: var(--color-grey);


### PR DESCRIPTION
Closes #109 

## What does this change?

Adds CSS so the spacing and border on the election overview page matches the layout on the ward summary page.

## How to test

Check any election page - e.g. election/general-election-july-2024 from demo module - and verify the spacing is better now than it had been between the "Seats won" and "Constituency results" sections. It should match the layout of the ward results.

## Images

![Screenshot 2024-08-05 at 16 38 25](https://github.com/user-attachments/assets/0d2b6038-a80c-407e-84d2-303b0373569f)

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.