### PR TITLE
removes call to non-existant CSS file

### DIFF
--- a/localgov_elections.libraries.yml
+++ b/localgov_elections.libraries.yml
@@ -10,7 +10,6 @@ election:
   version: 1.x
   css:
     theme:
-      css/variables.css: { }
       css/election-results.css: { }
 
 electoral_candidates_view:


### PR DESCRIPTION
Closes #120 

## What does this change?

Removes call to variables.css which was removed during a refactor a few weeks ago.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.