### PR TITLE
sets chart restults to use whole numbers

### DIFF
--- a/js/chartjs-override.js
+++ b/js/chartjs-override.js
@@ -33,6 +33,7 @@
       colour = null;
     });
     chart_data.data.datasets[0].backgroundColor = data;
+    chart_data.options.scales.x.ticks.precision = 0;
   };
 
   Drupal.behaviors.charts_override = {


### PR DESCRIPTION
Closes #108 

## What does this change?

Sets items on the x axis to use whole numbers instead of decimals. Currently, the results for "how many seats won" go from 0.0 to 1.0, so if a part wins 3 seats we report they have won 0.3 seats.

This fixes that.

## Images

### Before
![Screenshot 2024-08-05 at 16 55 04](https://github.com/user-attachments/assets/bebfef3b-c879-4c37-9b3f-1742d147195e)


### After
![Screenshot 2024-08-05 at 16 55 22](https://github.com/user-attachments/assets/d3397334-1519-4ed6-96f1-5aabe5778cc4)

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.