### PR TITLE
adds comma for thousands separator in results

### DIFF
--- a/config/install/views.view.localgov_election_results.yml
+++ b/config/install/views.view.localgov_election_results.yml
@@ -1188,7 +1188,7 @@ display:
           click_sort_column: value
           type: number_integer
           settings:
-            thousand_separator: ''
+            thousand_separator: ','
             prefix_suffix: true
           group_column: value
           group_columns: {  }


### PR DESCRIPTION
Closes #112 

## What does this change?

Adds a comma to thousands as separator for results count - e.g. 10000 becomes 10,000

## How to test
On demo content module, go to `/election/general-election-july-2024` and the results are like `10000`.

Switch to this branch, import the config, and the results should then be like `10,000`
