### PR TITLE
fix to show all parties on mobile

### DIFF
--- a/js/chartjs-override.js
+++ b/js/chartjs-override.js
@@ -42,7 +42,7 @@
             let data = e.detail;
             const id = data.drupalChartDivId;
             Drupal.localgov_elections.setChartColours(data, settings);
-            if (id === 'chart-election-results-via-parties-block-1') {
+            if (id === 'chart-election-results-via-parties-block-1' || 'chart-localgov-election-results-via-parties-block-1') {
               data.options.scales.y.grid = { display: false};
               data.options.scales.y.ticks.autoSkip = false;
             }


### PR DESCRIPTION
Closes #110

## What does this change?

At the moment, if there's more than 5 parties, our results view doesn't show the rest of them on mobile. This adds a check for the view id, and fixes it.

## How to test

In the demo module go to `election/general-election-july-2024`. 
Click on one of the edit button beside "Banbury" and add lots of more candidates to it each with a new political party. This will ensure there are lots of parties in the results view at the top of the page.
Resize the screen and then refresh the page. Note how you can't see all the parties.
Switch to this branch and refresh the page. You should now see all the parties.

## Images
### Before

![Screenshot 2024-08-06 at 11 18 48](https://github.com/user-attachments/assets/cb9906e0-ed58-4480-af2c-53221516f16b)


### After

![Screenshot 2024-08-06 at 11 18 59](https://github.com/user-attachments/assets/d10130c7-c132-4ad3-b111-38c462734678)

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.