### PR TITLE
adds label to hold/gain field for table

### DIFF
--- a/config/install/views.view.localgov_election_results.yml
+++ b/config/install/views.view.localgov_election_results.yml
@@ -958,7 +958,7 @@ display:
           group_type: group
           admin_label: ''
           plugin_id: field
-          label: ''
+          label: Hold/Gain
           exclude: false
           alter:
             alter_text: true


### PR DESCRIPTION
Closes #118 

## What does this change?

Adds "Hold/Gain" label to table column for results summary.

## How to test

Go to `election/general-election-july-2024` in the demo content and make sure there is a title in the hold/gain column on the Constituency Results table.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.