### PR TITLE
fix: test failure due to missing content moderation status on demo co…

### DIFF
--- a/modules/localgov_elections_demo_content/content/node/03c28275-05bd-4082-a629-101064faa287.yml
+++ b/modules/localgov_elections_demo_content/content/node/03c28275-05bd-4082-a629-101064faa287.yml
@@ -36,6 +36,9 @@ default:
   revision_translation_affected:
     -
       value: true
+  moderation_state:
+    -
+      value: published
   path:
     -
       alias: /election/general-election-july-2024/henley-and-thame

--- a/modules/localgov_elections_demo_content/content/node/23ffd187-52df-4106-9c19-af542d51a738.yml
+++ b/modules/localgov_elections_demo_content/content/node/23ffd187-52df-4106-9c19-af542d51a738.yml
@@ -29,6 +29,9 @@ default:
   revision_translation_affected:
     -
       value: true
+  moderation_state:
+    -
+      value: published
   path:
     -
       alias: /election/general-election-july-2024

--- a/modules/localgov_elections_demo_content/content/node/323fb108-c7e6-4ab8-89e1-8a2705ce6cfa.yml
+++ b/modules/localgov_elections_demo_content/content/node/323fb108-c7e6-4ab8-89e1-8a2705ce6cfa.yml
@@ -36,6 +36,9 @@ default:
   revision_translation_affected:
     -
       value: true
+  moderation_state:
+    -
+      value: published
   path:
     -
       alias: /election/general-election-july-2024/bicester-and-woodstock

--- a/modules/localgov_elections_demo_content/content/node/40b48ccc-4694-4718-96ae-a47cbdba8728.yml
+++ b/modules/localgov_elections_demo_content/content/node/40b48ccc-4694-4718-96ae-a47cbdba8728.yml
@@ -36,6 +36,9 @@ default:
   revision_translation_affected:
     -
       value: true
+  moderation_state:
+    -
+      value: published
   path:
     -
       alias: /election/general-election-july-2024/oxford-west-and-abingdon

--- a/modules/localgov_elections_demo_content/content/node/4d5aff55-8f5e-4195-acf0-a49cf259f84c.yml
+++ b/modules/localgov_elections_demo_content/content/node/4d5aff55-8f5e-4195-acf0-a49cf259f84c.yml
@@ -36,6 +36,9 @@ default:
   revision_translation_affected:
     -
       value: true
+  moderation_state:
+    -
+      value: published
   path:
     -
       alias: /election/general-election-july-2024/banbury

--- a/modules/localgov_elections_demo_content/content/node/5f652852-df67-4d5e-9e23-fc96c90a0f43.yml
+++ b/modules/localgov_elections_demo_content/content/node/5f652852-df67-4d5e-9e23-fc96c90a0f43.yml
@@ -36,6 +36,9 @@ default:
   revision_translation_affected:
     -
       value: true
+  moderation_state:
+    -
+      value: published
   path:
     -
       alias: /election/general-election-july-2024/oxford-east

--- a/modules/localgov_elections_demo_content/content/node/7d910eb2-029f-4688-a060-0319dc888ca1.yml
+++ b/modules/localgov_elections_demo_content/content/node/7d910eb2-029f-4688-a060-0319dc888ca1.yml
@@ -35,6 +35,9 @@ default:
   revision_translation_affected:
     -
       value: true
+  moderation_state:
+    -
+      value: published
   path:
     -
       alias: /election/general-election-july-2024/witney

--- a/modules/localgov_elections_demo_content/content/node/dd93c0fa-53b1-49fa-8dc7-066b83ea3bcb.yml
+++ b/modules/localgov_elections_demo_content/content/node/dd93c0fa-53b1-49fa-8dc7-066b83ea3bcb.yml
@@ -36,6 +36,9 @@ default:
   revision_translation_affected:
     -
       value: true
+  moderation_state:
+    -
+      value: published
   path:
     -
       alias: /election/general-election-july-2024/didcot-and-wantage

--- a/modules/localgov_elections_demo_content/localgov_elections_demo_content.module
+++ b/modules/localgov_elections_demo_content/localgov_elections_demo_content.module
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @file
+ * LocalGovDrupal elections demo module file.
+ */
+
+/**
+ * Implements hook_modules_installed().
+ */
+function localgov_elections_demo_content_modules_installed($modules, $is_syncing) {
+  if (!$is_syncing && in_array('default_content', $modules, TRUE)) {
+    // Regenerate all path aliases.
+    $nids = \Drupal::entityQuery('node')
+      ->condition('type', ['localgov_area_vote', 'localgov_election'], 'IN')
+      ->accessCheck(FALSE)
+      ->execute();
+    $nodes = \Drupal::entityTypeManager()
+      ->getStorage('node')
+      ->loadMultiple($nids);
+    foreach ($nodes as $node) {
+      \Drupal::service('pathauto.generator')->updateEntityAlias($node, 'update');
+    }
+  }
+}


### PR DESCRIPTION
## What does this change?

Fixes #132 , the test was failing due to the demo content missing the moderation status "published" and secondly the path aliases needed regenerating after install for the demo content to work. This has been handled the same as the main demo content module.

Coding standards fixes in this PR https://github.com/localgovdrupal/localgov_elections/pull/136