### PR TITLE
fix(security): allow paragraphs_table to be upgraded

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "drupal/entity_extra_field": "^2.1@RC",
         "drupal/color_field": "^3.0",
         "drupal/field_formatter_class":" ^1.5",
-        "drupal/paragraphs_table": "^1.6",
+        "drupal/paragraphs_table": "^1.23 || ^2.0",
         "cweagans/composer-patches": "^1.6",
         "drupal/charts": "^5.0",
         "drupal/views_field_view": "^1.0@beta",


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Fixes #134, `drupal/paragraphs_table` has two versions:

- 1.23 which supports Drupal ^8.8 || ^9 || ^10.1 and locks to 10.1 in composer
    - The previous release 1.21 allowed Drupal ^8.8 || ^9 || ^10
    - The release 1.22 introduced locking to 10.1 in composer
- 2.0 which supports Drupal ^10.2 || ^11

This fixes a security issue if you are currently on Drupal 10.3 and are using <1.23 as there is no way to get the security fix, so this change allows using either 1.23 or 2.0 of paragraphs_table depending on the Drupal core used.

## How to test

```
composer require --with-all-dependencies localgovdrupal/localgov_elections:"dev-fix/1.x/fix-paragraphs-table-security-update as 1.0.1"
```