### PR TITLE
fix: removes obsolete drupal/autocomplete_deluxe patch from composer.…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,6 @@
             "drupal/social_post_twitter": {
                 "Fix API integration (see https://www.drupal.org/project/social_post_twitter/issues/3392216)": "https://www.drupal.org/files/issues/2023-10-13/twitter_fixes.patch",
                 "Fix WOD (see https://www.drupal.org/project/social_post_twitter/issues/3436436#comment-15522882)": "https://www.drupal.org/files/issues/2024-03-27/sdk-init-fix.patch"
-            },
-            "drupal/autocomplete_deluxe": {
-                "Fix Help text not displaying (see: https://www.drupal.org/project/autocomplete_deluxe/issues/3171362)": "https://www.drupal.org/files/issues/2021-12-01/3171362-fix-help-text-not-display-2_0.patch"
             }
         }
     }


### PR DESCRIPTION
…json

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Re: #143 

<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

This change removes an obsolete patch from `composer.json` (see issue description).

## How to test

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

On a fresh localgov demo site:

- install this version of the module: `composer require localgovdrupal/localgov_elections:dev-fix/1.x/143-localgov-election-party-entity-ref-autocomplete-broken-on-fresh-install`
- enable the module: `drush pm:enable localgov_elections`
- create at least one term in the Party taxonomy
- create an Election
- create an Area Vote
- in the Area Vote, click "Add Candidate"
- begin typing the name of the Party into the Party field

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

I expect the autocomplete field to become usable. I don't know what bad effect this could have since the field is unusable in its current state, and the removed patch has been unnecessary for more than three years.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

As far as I understand the initial problem, the only way this could be _harmful_ would be if localgov_elections were still running alongside a very old version of `autocomplete_deluxe`. But this _should_ be impossible since `composer.json` requires a newer version of that module (2.0) than the version that made the patch obsolete (2.0.0-rc1).

## Images

<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

### Before


![Image](https://github.com/user-attachments/assets/08695d36-0829-4061-aef1-d597d8375312)

### After

![image](https://github.com/user-attachments/assets/7952a88d-a9a8-4027-997f-f6b528a668c0)


## Accessibility

n/a