### PR TITLE
Fix PHP static analysis errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   tests:
-    uses: localgovdrupal/localgov_shared_workflows/.github/workflows/test-module.yml@1.x
+    uses: localgovdrupal/localgov_shared_workflows/.github/workflows/test-module.yml@1.x-d10
     with:
       project: 'localgovdrupal/localgov_elections'
       project_path: 'web/modules/contrib/localgov_elections'

--- a/config/optional/localgov_menu_link_group.localgov_menu_link_group.localgov_menu_link_group_election.yml
+++ b/config/optional/localgov_menu_link_group.localgov_menu_link_group.localgov_menu_link_group_election.yml
@@ -3,8 +3,8 @@ status: true
 dependencies:
   enforced:
     module:
-    - localgov_elections
-    - localgov_menu_link_group
+      - localgov_elections
+      - localgov_menu_link_group
 id: localgov_menu_link_group_election
 group_label: Election
 weight: 13

--- a/css/election-menu.css
+++ b/css/election-menu.css
@@ -9,8 +9,8 @@
 
 .election-menu__list-item {
   display: flex;
-  margin-bottom: 0.5rem;
   width: 100%;
+  margin-bottom: 0.5rem;
   padding: 1rem;
 }
 

--- a/css/election-menu.css
+++ b/css/election-menu.css
@@ -3,26 +3,26 @@
 }
 
 .election-menu__list {
-  list-style-type: none;
   padding: 0;
+  list-style-type: none;
 }
 
 .election-menu__list-item {
-  margin-bottom: 0.5rem;
   display: flex;
+  margin-bottom: 0.5rem;
   width: 100%;
   padding: 1rem;
 }
 
 .election-menu__list-item a {
-  width: 100%;
   display: block;
+  width: 100%;
   text-decoration: underline;
 }
 
 .election-menu__list-item.active {
-  background-color: var(--color-accent);
   color: white;
+  background-color: var(--color-accent);
 }
 
 .election-menu__list-item.active a {
@@ -30,7 +30,7 @@
 }
 
 .election-menu__list-icon {
-  width: .75rem;
+  width: 0.75rem;
 }
 .election-menu__list-item.active .election-menu__list-icon path {
   fill: white;

--- a/css/election-results.css
+++ b/css/election-results.css
@@ -4,7 +4,6 @@
   border-top: var(--table-border);
 }
 
-
 .county-summary__subheading {
   padding: 1rem;
   background-color: var(--color-grey);
@@ -26,12 +25,12 @@
 }
 
 .county-summary .dot {
-  height: 1rem;
   width: 1rem;
-  border-radius: 50%;
+  height: 1rem;
   display: inline-block;
-  border: 1px solid black;
   margin-right: 0.5rem;
+  border-radius: 50%;
+  border: 1px solid black;
 }
 
 .county-summary .label-wrapper {
@@ -53,12 +52,12 @@
 }
 
 .county-summary .party {
-  text-transform: uppercase;
   padding: 0.25rem;
+  text-transform: uppercase;
   color: white;
-  font-weight: bold;
-  font-family: Sans-Serif;
   width: fit-content;
+  font-family: Sans-Serif;
+  font-weight: bold;
 }
 
 .county-summary .views-field-election-majority {
@@ -67,8 +66,8 @@
 
 .county-summary .seat-not-contested {
   display: inline-flex;
-  border: 1px solid black;
   text-transform: uppercase;
-  font-weight: bold;
+  border: 1px solid black;
   padding: 0.25rem;
+  font-weight: bold;
 }

--- a/css/election-results.css
+++ b/css/election-results.css
@@ -67,7 +67,7 @@
 .county-summary .seat-not-contested {
   display: inline-flex;
   padding: 0.25rem;
-  border: 1px solid black;
   text-transform: uppercase;
+  border: 1px solid black;
   font-weight: bold;
 }

--- a/css/election-results.css
+++ b/css/election-results.css
@@ -38,8 +38,8 @@
 }
 
 .county-summary .hold-or-gain {
-  padding: 0.25rem;
   margin: 0 0.25rem;
+  padding: 0.25rem;
 }
 
 .county-summary .hold {
@@ -52,10 +52,10 @@
 }
 
 .county-summary .party {
-  padding: 0.25rem;
   width: fit-content;
-  color: white;
+  padding: 0.25rem;
   text-transform: uppercase;
+  color: white;
   font-family: Sans-Serif;
   font-weight: bold;
 }
@@ -66,8 +66,8 @@
 
 .county-summary .seat-not-contested {
   display: inline-flex;
-  text-transform: uppercase;
   padding: 0.25rem;
   border: 1px solid black;
+  text-transform: uppercase;
   font-weight: bold;
 }

--- a/css/election-results.css
+++ b/css/election-results.css
@@ -25,12 +25,12 @@
 }
 
 .county-summary .dot {
+  display: inline-block;
   width: 1rem;
   height: 1rem;
-  display: inline-block;
   margin-right: 0.5rem;
-  border-radius: 50%;
   border: 1px solid black;
+  border-radius: 50%;
 }
 
 .county-summary .label-wrapper {
@@ -53,9 +53,9 @@
 
 .county-summary .party {
   padding: 0.25rem;
-  text-transform: uppercase;
-  color: white;
   width: fit-content;
+  color: white;
+  text-transform: uppercase;
   font-family: Sans-Serif;
   font-weight: bold;
 }
@@ -67,7 +67,7 @@
 .county-summary .seat-not-contested {
   display: inline-flex;
   text-transform: uppercase;
-  border: 1px solid black;
   padding: 0.25rem;
+  border: 1px solid black;
   font-weight: bold;
 }

--- a/css/election-timeline.css
+++ b/css/election-timeline.css
@@ -13,8 +13,8 @@
 }
 
 .view-election-results-timeline .key-result {
-  text-transform: uppercase;
   display: flex;
+  text-transform: uppercase;
 }
 
 .view-election-results-timeline .key-result .winning-party {
@@ -39,8 +39,8 @@
 }
 
 .view-election-results-timeline .winning-party.ldm {
-  background-color: var(--liberal-democrats);
   color: black;
+  background-color: var(--liberal-democrats);
 }
 
 .view-election-results-timeline .winning-party.ind {
@@ -48,8 +48,8 @@
 }
 
 .view-election-results-timeline .hold-gain {
-  padding: 0.25rem;
   margin: 0 0.25rem;
+  padding: 0.25rem;
 }
 
 .view-election-results-timeline .hold {

--- a/css/electoral-candidates-view.css
+++ b/css/electoral-candidates-view.css
@@ -1,5 +1,5 @@
 .view-electoral-candidates a > i {
-  font-weight: normal;
-  font-size: 1.2rem;
   margin-right: 0.5rem;
+  font-size: 1.2rem;
+  font-weight: normal;
 }

--- a/css/ward-results.css
+++ b/css/ward-results.css
@@ -25,12 +25,12 @@
 }
 
 .ward-result .dot {
-  height: 1rem;
   width: 1rem;
-  border-radius: 50%;
+  height: 1rem;
   display: inline-block;
-  border: 1px solid black;
   margin-right: 0.5rem;
+  border: 1px solid black;
+  border-radius: 50%;
 }
 
 .ward-result .label-wrapper {
@@ -38,8 +38,8 @@
 }
 
 .ward-result .results-analysis-grid > * {
-  border-bottom: var(--table-border);
   margin-bottom: 0.1rem;
+  border-bottom: var(--table-border);
 }
 
 .ward-result .box > * {

--- a/css/ward-results.css
+++ b/css/ward-results.css
@@ -14,7 +14,6 @@
   border-top: var(--table-border);
 }
 
-
 .ward-result .box {
   padding: 1rem;
 }
@@ -25,9 +24,9 @@
 }
 
 .ward-result .dot {
+  display: inline-block;
   width: 1rem;
   height: 1rem;
-  display: inline-block;
   margin-right: 0.5rem;
   border: 1px solid black;
   border-radius: 50%;

--- a/localgov_elections.install
+++ b/localgov_elections.install
@@ -11,7 +11,7 @@ use Drupal\Core\Entity\EntityStorageException;
 /**
  * Implements hook_install().
  */
-function localgov_elections_install($is_syncing) {
+function localgov_elections_install($is_syncing): void {
   $module_path = \Drupal::getContainer()
     ->get('module_handler')
     ->getModule('localgov_elections')
@@ -30,7 +30,7 @@ function localgov_elections_install($is_syncing) {
 /**
  * Implements hook_uninstall().
  */
-function localgov_elections_uninstall($is_syncing) {
+function localgov_elections_uninstall($is_syncing): void {
   $storage_handler = \Drupal::entityTypeManager()
     ->getStorage('node');
   $nodes = $storage_handler->loadByProperties(['type' => 'localgov_election']);
@@ -50,7 +50,7 @@ function localgov_elections_uninstall($is_syncing) {
 /**
  * Update results view for already installed module.
  */
-function localgov_elections_update_10001(&$sandbox) {
+function localgov_elections_update_10001(&$sandbox): void {
 
   $config_obj = \Drupal::configFactory()->getEditable('views.view.localgov_election_results');
   $config_obj->set('display.block_3.display_options.fields.localgov_election_votes.alter.alter_text', TRUE);
@@ -63,7 +63,7 @@ function localgov_elections_update_10001(&$sandbox) {
 /**
  * Make election results area more robust for when candidates have no surname.
  */
-function localgov_elections_update_10002() {
+function localgov_elections_update_10002(): void {
   $module_path = \Drupal::getContainer()
     ->get('module_handler')
     ->getModule('localgov_elections')

--- a/localgov_elections.module
+++ b/localgov_elections.module
@@ -20,7 +20,7 @@ use Drupal\views\ViewExecutable;
 /**
  * Implements hook_theme().
  */
-function localgov_elections_theme($existing, $type, $theme, $path) {
+function localgov_elections_theme($existing, $type, $theme, $path): mixed {
   return [
     'ward_result' => [
       'variables' => [
@@ -45,7 +45,7 @@ function localgov_elections_theme($existing, $type, $theme, $path) {
 /**
  * Implements hook_entity_presave().
  */
-function localgov_elections_entity_presave(EntityInterface $entity) {
+function localgov_elections_entity_presave(EntityInterface $entity): void {
   if ($entity->getEntityTypeId() == 'node' && $entity->getType() == 'localgov_area_vote') {
 
     // Trigger when division vote saved to update the winning candidate only
@@ -111,7 +111,7 @@ function localgov_elections_entity_presave(EntityInterface $entity) {
  * @return void
  *   Returns nothing.
  */
-function localgov_elections_generate_election_aliases(NodeInterface $entity) {
+function localgov_elections_generate_election_aliases(NodeInterface $entity): void {
   if ($entity->getType() == 'localgov_election') {
 
     // Check if the parent election node is aliased.
@@ -171,7 +171,7 @@ function localgov_elections_generate_election_aliases(NodeInterface $entity) {
 /**
  * Implements hook_ENTITY_TYPE_update().
  */
-function localgov_elections_path_alias_update(EntityInterface $entity) {
+function localgov_elections_path_alias_update(EntityInterface $entity): void {
   /** @var \Drupal\path_alias\Entity\PathAlias $original_entity */
   $original_entity = $entity->original;
 
@@ -197,7 +197,7 @@ function localgov_elections_path_alias_update(EntityInterface $entity) {
 /**
  * Implements hook_ENTITY_TYPE_insert().
  */
-function localgov_elections_path_alias_insert(EntityInterface $entity) {
+function localgov_elections_path_alias_insert(EntityInterface $entity): void {
   $path = $entity->getPath();
   $url = Url::fromUserInput($path);
   $params = $url->getRouteParameters();
@@ -219,7 +219,7 @@ function localgov_elections_path_alias_insert(EntityInterface $entity) {
  * @param string $alias
  *   The alias path (e.g., '/my-custom-alias').
  */
-function localgov_elections_delete_alias_by_alias($alias) {
+function localgov_elections_delete_alias_by_alias($alias): void {
   $storage = \Drupal::entityTypeManager()->getStorage('path_alias');
   $alias_entities = $storage->loadByProperties(['alias' => $alias]);
 
@@ -241,7 +241,7 @@ function localgov_elections_delete_alias_by_alias($alias) {
  * @return void
  *   Returns nothing.
  */
-function localgov_elections_delete_election_aliases(NodeInterface $election) {
+function localgov_elections_delete_election_aliases(NodeInterface $election): void {
 
   // Map page.
   $map_page_url = Url::fromRoute('view.localgov_election_electoral_map.page_1', ['node' => $election->id()]);
@@ -285,7 +285,7 @@ function localgov_elections_delete_election_aliases(NodeInterface $election) {
  * @return bool
  *   True if alias exists else false.
  */
-function localgov_elections_alias_exists(string $alias) {
+function localgov_elections_alias_exists(string $alias): bool {
   // Get the alias manager service.
   $alias_manager = \Drupal::service('path_alias.manager');
 
@@ -308,7 +308,7 @@ function localgov_elections_alias_exists(string $alias) {
  * @return string|null
  *   Returns alias or null.
  */
-function localgov_elections_get_entity_alias(string $entity_type, int|string $entity_id) {
+function localgov_elections_get_entity_alias(string $entity_type, int|string $entity_id): ?string {
   // Load the entity.
   $entity = \Drupal::entityTypeManager()->getStorage($entity_type)->load($entity_id);
 
@@ -357,7 +357,7 @@ function localgov_elections_create_alias(string $path, string $alias): bool {
 /**
  * Implements hook_entity_predelete().
  */
-function localgov_elections_entity_predelete(EntityInterface $entity) {
+function localgov_elections_entity_predelete(EntityInterface $entity): void {
   // Triggered just before an Election node is deleted.
   if ($entity->getEntityTypeId() == 'node' && $entity->getType() == 'localgov_election') {
     $election_id = $entity->id();
@@ -395,7 +395,7 @@ function localgov_elections_entity_predelete(EntityInterface $entity) {
 /**
  * Implements hook_views_data_alter().
  */
-function localgov_elections_views_data_alter(array &$data) {
+function localgov_elections_views_data_alter(array &$data): void {
   $data['node']['ward_majority'] = [
     'title' => t('Ward majority'),
     'field' => [
@@ -499,7 +499,7 @@ function localgov_elections_views_data_alter(array &$data) {
 /**
  * Implements hook_menu_local_tasks_alter().
  */
-function localgov_elections_menu_local_tasks_alter(&$data, $route_name) {
+function localgov_elections_menu_local_tasks_alter(&$data, $route_name): void {
   // Hide 'Results timelines' tab from all nodes except 'Election' content
   // types.
   $node = \Drupal::routeMatch()->getParameter('node');
@@ -541,7 +541,7 @@ function localgov_elections_menu_local_tasks_alter(&$data, $route_name) {
 /**
  * Implements hook_preprocess_HOOK().
  */
-function localgov_elections_preprocess_node(&$variables) {
+function localgov_elections_preprocess_node(&$variables): void {
   $node = $variables['elements']['#node'];
 
   if ($node->bundle() == 'localgov_area_vote') {
@@ -650,7 +650,7 @@ function localgov_elections_preprocess_node(&$variables) {
 /**
  * Implements hook_views_pre_render().
  */
-function localgov_elections_views_pre_render(ViewExecutable $view) {
+function localgov_elections_views_pre_render(ViewExecutable $view): void {
 
   if ($view->id() == 'localgov_electoral_candidates') {
     $view->element['#attached']['library'][] = 'localgov_elections/electoral_candidates_view';
@@ -676,7 +676,7 @@ function localgov_elections_views_pre_render(ViewExecutable $view) {
 /**
  * Implements hook_views_post_render().
  */
-function localgov_elections_views_post_render(ViewExecutable $view, array &$output, CachePluginBase $cache) {
+function localgov_elections_views_post_render(ViewExecutable $view, array &$output, CachePluginBase $cache): void {
   if ($view->id() == 'localgov_election_results_via_parties') {
     // Remove rows from rendered output where party is not standing in election
     // (these rows will be NULL)
@@ -700,7 +700,7 @@ function localgov_elections_views_post_render(ViewExecutable $view, array &$outp
 /**
  * Implements hook_chart_definition_CHART_ID_alter().
  */
-function localgov_elections_chart_definition_localgov_election_results_via_parties_block_1_alter(array &$definition, array $element, $chart_id) {
+function localgov_elections_chart_definition_localgov_election_results_via_parties_block_1_alter(array &$definition, array $element, $chart_id): void {
   $definition['yAxis'][0]['allowDecimals'] = FALSE;
   if (!empty($definition['series'][0]['data'])) {
     foreach ($definition['series'][0]['data'] as &$entry) {
@@ -746,7 +746,7 @@ function localgov_elections_chart_definition_localgov_election_results_via_parti
 /**
  * Implements hook_page_attachments_alter().
  */
-function localgov_elections_page_attachments(array &$attachments) {
+function localgov_elections_page_attachments(array &$attachments): void {
   $route = Drupal::routeMatch();
 
   if ($node = $route->getParameter('node')) {
@@ -764,7 +764,7 @@ function localgov_elections_page_attachments(array &$attachments) {
 /**
  * Implements hook_chart_alter().
  */
-function localgov_elections_chart_alter(array &$element, $chart_id) {
+function localgov_elections_chart_alter(array &$element, $chart_id): void {
   $config_obj = \Drupal::configFactory()->getEditable('views.view.localgov_election_results_via_parties');
   $chart_library = $config_obj->get('display.default.display_options.style.options.chart_settings.library');
   if ($chart_library == 'highcharts') {
@@ -779,7 +779,7 @@ function localgov_elections_chart_alter(array &$element, $chart_id) {
 /**
  * Calculates majority.
  */
-function _localgov_elections_calc_majority() {
+function _localgov_elections_calc_majority(): ?int {
   $node = \Drupal::routeMatch()->getParameter('node');
   $majority = NULL;
   if ($node instanceof NodeInterface) {
@@ -797,12 +797,13 @@ function _localgov_elections_calc_majority() {
       return (int) $majority;
     }
   }
+  return NULL;
 }
 
 /**
  * Gets party colours.
  */
-function _localgov_elections_party_colours() {
+function _localgov_elections_party_colours(): array {
   $results = [];
   $terms = Drupal::entityTypeManager()
     ->getStorage('taxonomy_term')
@@ -829,7 +830,7 @@ function _localgov_elections_party_colours() {
 /**
  * Implements hook_preprocess_HOOK().
  */
-function localgov_elections_preprocess_election_menu(&$variables) {
+function localgov_elections_preprocess_election_menu(&$variables): void {
   $attributes = new Attribute();
   $attributes->setAttribute('id', 'election-menu');
   $variables['attributes'] = $attributes;
@@ -854,7 +855,7 @@ function localgov_elections_preprocess_election_menu(&$variables) {
 /**
  * Implements hook_preprocess_HOOK().
  */
-function localgov_elections_preprocess_block(&$variables) {
+function localgov_elections_preprocess_block(&$variables): void {
   if ($variables['base_plugin_id'] == 'localgov_elections_electionmenu') {
     $variables['attributes']['class'][] = 'election-menu-block';
   }
@@ -875,14 +876,14 @@ function localgov_elections_preprocess_block(&$variables) {
 /**
  * Implements hook_form_BASE_FORM_ID_alter().
  */
-function localgov_elections_form_node_localgov_area_vote_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+function localgov_elections_form_node_localgov_area_vote_edit_form_alter(&$form, FormStateInterface $form_state, $form_id): void {
   $form['#validate'][] = "localgov_elections_area_vote_form_validation";
 }
 
 /**
  * Implements hook_form_BASE_FORM_ID_alter().
  */
-function localgov_elections_form_taxonomy_term_localgov_party_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+function localgov_elections_form_taxonomy_term_localgov_party_form_alter(&$form, FormStateInterface $form_state, $form_id): void {
   if (isset($form["name"]["widget"][0]['value'])) {
     $form["name"]["widget"][0]['value']["#description"] = t("The party name. Do not enter brackets in the party nameph.");
   }
@@ -891,7 +892,7 @@ function localgov_elections_form_taxonomy_term_localgov_party_form_alter(&$form,
 /**
  * Validation function for area vote node forms.
  */
-function localgov_elections_area_vote_form_validation($form, FormStateInterface $form_state) {
+function localgov_elections_area_vote_form_validation($form, FormStateInterface $form_state): void {
   $contested = $form_state->getValue('localgov_election_no_contest')['value'];
   $candidates = $form_state->getValue('localgov_election_candidates');
   $candidate_keys = array_filter(array_keys($candidates), function ($key) {

--- a/modules/localgov_elections_constituency_provider/src/Controller/UkConstituencyTwentyFourAutoComplete.php
+++ b/modules/localgov_elections_constituency_provider/src/Controller/UkConstituencyTwentyFourAutoComplete.php
@@ -78,7 +78,7 @@ class UkConstituencyTwentyFourAutoComplete extends ControllerBase {
   /**
    * {@inheritDoc}
    */
-  public static function create(ContainerInterface $container) {
+  public static function create(ContainerInterface $container): static {
     return new static(
         $container->get('http_client'),
         $container->get('cache.default'),
@@ -97,7 +97,7 @@ class UkConstituencyTwentyFourAutoComplete extends ControllerBase {
    *
    * @throws \GuzzleHttp\Exception\GuzzleException
    */
-  private function fetchConstituencies() {
+  private function fetchConstituencies(): ?array {
     if ($this->cacheBackend->get(CacheKey::CONSTITUENCY_NAMES_KEY) === FALSE) {
       $response = $this->httpClient->get($this->constituencyEndpoint);
       $body = $response->getBody()->getContents();

--- a/modules/localgov_elections_constituency_provider/src/Form/UkConstituencyTwentyFourProviderDownloadForm.php
+++ b/modules/localgov_elections_constituency_provider/src/Form/UkConstituencyTwentyFourProviderDownloadForm.php
@@ -44,7 +44,7 @@ class UkConstituencyTwentyFourProviderDownloadForm implements BoundaryProviderSu
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container) {
+  public static function create(ContainerInterface $container): static {
     return new static(
         $container->get('http_client'),
         $container->get('request_stack'),
@@ -92,7 +92,7 @@ class UkConstituencyTwentyFourProviderDownloadForm implements BoundaryProviderSu
   /**
    * {@inheritDoc}
    */
-  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
 
     // Add our autocomplete field.
     $form['constituencies'] = [
@@ -110,7 +110,7 @@ class UkConstituencyTwentyFourProviderDownloadForm implements BoundaryProviderSu
   /**
    * {@inheritDoc}
    */
-  public function validateConfigurationForm(array &$form, FormStateInterface $form_state) {
+  public function validateConfigurationForm(array &$form, FormStateInterface $form_state): void {
     // Make sure we only get triggered on submit and not ajax events too.
     if ($form_state->getTriggeringElement()['#type'] == 'submit') {
       $values = str_getcsv($form_state->getValue('constituencies'));
@@ -131,7 +131,7 @@ class UkConstituencyTwentyFourProviderDownloadForm implements BoundaryProviderSu
   /**
    * {@inheritDoc}
    */
-  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
     // Map the constituencies into an array instead.
     $constituencies = $form_state->getValue('constituencies');
     $values = str_getcsv($constituencies);

--- a/modules/localgov_elections_constituency_provider/src/Plugin/BoundaryProvider/UkConstituencyTwentyFourProvider.php
+++ b/modules/localgov_elections_constituency_provider/src/Plugin/BoundaryProvider/UkConstituencyTwentyFourProvider.php
@@ -62,7 +62,7 @@ class UkConstituencyTwentyFourProvider extends BoundaryProviderPluginBase implem
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
     return new static(
         $configuration,
         $plugin_id,
@@ -106,14 +106,14 @@ class UkConstituencyTwentyFourProvider extends BoundaryProviderPluginBase implem
   /**
    * {@inheritdoc}
    */
-  public function defaultConfiguration() {
+  public function defaultConfiguration(): array {
     return [];
   }
 
   /**
    * {@inheritdoc}
    */
-  public function isConfigurable() {
+  public function isConfigurable(): true {
     return TRUE;
   }
 
@@ -129,7 +129,7 @@ class UkConstituencyTwentyFourProvider extends BoundaryProviderPluginBase implem
    *
    * @throws \GuzzleHttp\Exception\GuzzleException
    */
-  private function fetchBoundaryInformation(array $constituencies) {
+  private function fetchBoundaryInformation(array $constituencies): array {
     // Build the rest of the endpoint. The where condition needs added.
     $features = [];
     // Create an array to hold the encoded parts.
@@ -160,7 +160,7 @@ class UkConstituencyTwentyFourProvider extends BoundaryProviderPluginBase implem
   /**
    * {@inheritdoc}
    */
-  public function createBoundaries(BoundarySourceInterface $entity, array $form_values) {
+  public function createBoundaries(BoundarySourceInterface $entity, array $form_values): void {
     $boundaries = $this->fetchBoundaryInformation($form_values["plugin"]["config"]["constituencies"]);
     $election = $form_values['localgov_election'];
     $election_node = $this->nodeStorage->load($election);
@@ -188,21 +188,21 @@ class UkConstituencyTwentyFourProvider extends BoundaryProviderPluginBase implem
   /**
    * {@inheritDoc}
    */
-  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
     return [];
   }
 
   /**
    * {@inheritDoc}
    */
-  public function validateConfigurationForm(array &$form, FormStateInterface $form_state) {
+  public function validateConfigurationForm(array &$form, FormStateInterface $form_state): void {
 
   }
 
   /**
    * {@inheritDoc}
    */
-  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
 
   }
 

--- a/modules/localgov_elections_constituency_provider/tests/src/FunctionalJavascript/AutocompleteTest.php
+++ b/modules/localgov_elections_constituency_provider/tests/src/FunctionalJavascript/AutocompleteTest.php
@@ -86,7 +86,7 @@ final class AutocompleteTest extends WebDriverTestBase {
   /**
    * Tests that that autocomplete field shows options correctly.
    */
-  public function testAutocompleteFieldShowsOptions() {
+  public function testAutocompleteFieldShowsOptions(): void {
     // Navigate to the homepage.
     $id = $this->election->id();
     $this->drupalGet("/node/$id/boundary-fetch");

--- a/modules/localgov_elections_demo_content/localgov_elections_demo_content.module
+++ b/modules/localgov_elections_demo_content/localgov_elections_demo_content.module
@@ -8,7 +8,7 @@
 /**
  * Implements hook_modules_installed().
  */
-function localgov_elections_demo_content_modules_installed($modules, $is_syncing) {
+function localgov_elections_demo_content_modules_installed($modules, $is_syncing): void {
   if (!$is_syncing && in_array('default_content', $modules, TRUE)) {
     // Regenerate all path aliases.
     $nids = \Drupal::entityQuery('node')

--- a/modules/localgov_elections_ons_twenty_four_divisions/src/Form/OnsTwentyFourDivisionsDownloadForm.php
+++ b/modules/localgov_elections_ons_twenty_four_divisions/src/Form/OnsTwentyFourDivisionsDownloadForm.php
@@ -34,7 +34,7 @@ class OnsTwentyFourDivisionsDownloadForm implements BoundaryProviderSubformInter
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container) {
+  public static function create(ContainerInterface $container): static {
     return new static(
       $container->get('http_client'),
       $container->get('request_stack'),
@@ -61,7 +61,7 @@ class OnsTwentyFourDivisionsDownloadForm implements BoundaryProviderSubformInter
   /**
    * {@inheritDoc}
    */
-  public function setPlugin(BoundaryProviderInterface $plugin) {
+  public function setPlugin(BoundaryProviderInterface $plugin): void {
     $this->plugin = $plugin;
   }
 
@@ -75,7 +75,7 @@ class OnsTwentyFourDivisionsDownloadForm implements BoundaryProviderSubformInter
   /**
    * {@inheritdoc}
    */
-  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
     $opts = $this->getAreasToDownload();
     $form['options'] =
       [
@@ -148,14 +148,14 @@ class OnsTwentyFourDivisionsDownloadForm implements BoundaryProviderSubformInter
   /**
    * {@inheritdoc}
    */
-  public function validateConfigurationForm(array &$form, FormStateInterface $form_state) {
+  public function validateConfigurationForm(array &$form, FormStateInterface $form_state): void {
     // @todo any validation needed?
   }
 
   /**
    * {@inheritdoc}
    */
-  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
     // @todo any submit handling needed?
   }
 

--- a/modules/localgov_elections_ons_twenty_four_divisions/src/Plugin/BoundaryProvider/OnsTwentyFourDivisions.php
+++ b/modules/localgov_elections_ons_twenty_four_divisions/src/Plugin/BoundaryProvider/OnsTwentyFourDivisions.php
@@ -272,7 +272,7 @@ class OnsTwentyFourDivisions extends BoundaryProviderPluginBase implements Conta
   /**
    * {@inheritdoc}
    */
-  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
     // Nothing to do.
   }
 

--- a/modules/localgov_elections_ons_twenty_four_divisions/src/Plugin/BoundaryProvider/OnsTwentyFourDivisions.php
+++ b/modules/localgov_elections_ons_twenty_four_divisions/src/Plugin/BoundaryProvider/OnsTwentyFourDivisions.php
@@ -54,7 +54,7 @@ class OnsTwentyFourDivisions extends BoundaryProviderPluginBase implements Conta
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
     return new static(
         $configuration,
         $plugin_id,
@@ -95,21 +95,21 @@ class OnsTwentyFourDivisions extends BoundaryProviderPluginBase implements Conta
   /**
    * {@inheritdoc}
    */
-  public function defaultConfiguration() {
+  public function defaultConfiguration(): array {
     return [];
   }
 
   /**
    * {@inheritdoc}
    */
-  public function isConfigurable() {
+  public function isConfigurable(): true {
     return TRUE;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
 
     $form['cty'] = [
       '#type' => 'textfield',
@@ -188,7 +188,7 @@ class OnsTwentyFourDivisions extends BoundaryProviderPluginBase implements Conta
   /**
    * {@inheritdoc}
    */
-  public function createBoundaries(BoundarySourceInterface $entity, array $form_values) {
+  public function createBoundaries(BoundarySourceInterface $entity, array $form_values): void {
     $vals = array_keys(array_filter($form_values['plugin']['config']['options'], function ($item) {
       return $item !== 0;
     }));
@@ -226,7 +226,7 @@ class OnsTwentyFourDivisions extends BoundaryProviderPluginBase implements Conta
   /**
    * {@inheritDoc}
    */
-  public function validateConfigurationForm(array &$form, FormStateInterface $form_state) {
+  public function validateConfigurationForm(array &$form, FormStateInterface $form_state): void {
     $lad = $form_state->getValue('lad');
     $cty = $form_state->getValue('cty');
     $url = self::URL_SERVICES_LU;

--- a/modules/localgov_elections_ons_twenty_four_parishes/README.md
+++ b/modules/localgov_elections_ons_twenty_four_parishes/README.md
@@ -21,7 +21,7 @@ titled "[Local Authority Districts (April 2023) Names and Codes in the United Ki
 
 ## Boundary Fetching Process
 
-The boundary fetching process used by the ONS Divisions 2024 Plugin is fairly simple and can be described in a few steps:
+The boundary fetching process used by the ONS Parish 2024 Plugin is fairly simple and can be described in a few steps:
 
 1. Get the District Code on the plugin configuration form. This limits the fetched boundaries to a
    specific area. The plugin form validates the district code is valid, so you can't just enter anything here.

--- a/modules/localgov_elections_ons_twenty_four_parishes/src/Form/OnsTwentyFourParishesDownloadForm.php
+++ b/modules/localgov_elections_ons_twenty_four_parishes/src/Form/OnsTwentyFourParishesDownloadForm.php
@@ -34,7 +34,7 @@ class OnsTwentyFourParishesDownloadForm implements BoundaryProviderSubformInterf
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container) {
+  public static function create(ContainerInterface $container): static {
     return new static(
       $container->get('http_client'),
       $container->get('request_stack'),
@@ -61,7 +61,7 @@ class OnsTwentyFourParishesDownloadForm implements BoundaryProviderSubformInterf
   /**
    * {@inheritDoc}
    */
-  public function setPlugin(BoundaryProviderInterface $plugin) {
+  public function setPlugin(BoundaryProviderInterface $plugin): void {
     $this->plugin = $plugin;
   }
 
@@ -75,7 +75,7 @@ class OnsTwentyFourParishesDownloadForm implements BoundaryProviderSubformInterf
   /**
    * {@inheritdoc}
    */
-  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
     $opts = $this->getAreasToDownload();
     $form['options'] =
       [
@@ -131,14 +131,14 @@ class OnsTwentyFourParishesDownloadForm implements BoundaryProviderSubformInterf
   /**
    * {@inheritdoc}
    */
-  public function validateConfigurationForm(array &$form, FormStateInterface $form_state) {
+  public function validateConfigurationForm(array &$form, FormStateInterface $form_state): void {
     // @todo any validation needed?
   }
 
   /**
    * {@inheritdoc}
    */
-  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
     // @todo any submit handling needed?
   }
 

--- a/modules/localgov_elections_ons_twenty_four_parishes/src/Plugin/BoundaryProvider/OnsTwentyFourParishes.php
+++ b/modules/localgov_elections_ons_twenty_four_parishes/src/Plugin/BoundaryProvider/OnsTwentyFourParishes.php
@@ -49,7 +49,7 @@ class OnsTwentyFourParishes extends BoundaryProviderPluginBase implements Contai
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
     return new static(
       $configuration,
       $plugin_id,
@@ -90,21 +90,21 @@ class OnsTwentyFourParishes extends BoundaryProviderPluginBase implements Contai
   /**
    * {@inheritdoc}
    */
-  public function defaultConfiguration() {
+  public function defaultConfiguration(): array {
     return [];
   }
 
   /**
    * {@inheritdoc}
    */
-  public function isConfigurable() {
+  public function isConfigurable(): true {
     return TRUE;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
 
     $form['lad'] = [
       '#type' => 'textfield',
@@ -176,7 +176,7 @@ class OnsTwentyFourParishes extends BoundaryProviderPluginBase implements Contai
   /**
    * {@inheritdoc}
    */
-  public function createBoundaries(BoundarySourceInterface $entity, array $form_values) {
+  public function createBoundaries(BoundarySourceInterface $entity, array $form_values): void {
     $vals = array_keys(array_filter($form_values['plugin']['config']['options'], function ($item) {
       return $item !== 0;
     }));
@@ -213,7 +213,7 @@ class OnsTwentyFourParishes extends BoundaryProviderPluginBase implements Contai
   /**
    * {@inheritDoc}
    */
-  public function validateConfigurationForm(array &$form, FormStateInterface $form_state) {
+  public function validateConfigurationForm(array &$form, FormStateInterface $form_state): void {
     $lad = $form_state->getValue('lad');
     $url = self::URL_SERVICES_PAR;
     $params = [
@@ -243,7 +243,7 @@ class OnsTwentyFourParishes extends BoundaryProviderPluginBase implements Contai
   /**
    * {@inheritdoc}
    */
-  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
     // Nothing to do.
   }
 

--- a/modules/localgov_elections_ons_twenty_three_wards/src/Form/OnsTwentyThreeWardsDownloadForm.php
+++ b/modules/localgov_elections_ons_twenty_three_wards/src/Form/OnsTwentyThreeWardsDownloadForm.php
@@ -35,7 +35,7 @@ class OnsTwentyThreeWardsDownloadForm implements BoundaryProviderSubformInterfac
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container) {
+  public static function create(ContainerInterface $container): static {
     return new static($container->get('http_client'), $container->get('request_stack'));
   }
 
@@ -62,7 +62,7 @@ class OnsTwentyThreeWardsDownloadForm implements BoundaryProviderSubformInterfac
   /**
    * {@inheritDoc}
    */
-  public function setPlugin(BoundaryProviderInterface $plugin) {
+  public function setPlugin(BoundaryProviderInterface $plugin): void {
     $this->plugin = $plugin;
   }
 
@@ -76,7 +76,7 @@ class OnsTwentyThreeWardsDownloadForm implements BoundaryProviderSubformInterfac
   /**
    * {@inheritdoc}
    */
-  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
     $opts = [];
     $form['options'] =
         [
@@ -103,14 +103,14 @@ class OnsTwentyThreeWardsDownloadForm implements BoundaryProviderSubformInterfac
   /**
    * {@inheritdoc}
    */
-  public function validateConfigurationForm(array &$form, FormStateInterface $form_state) {
+  public function validateConfigurationForm(array &$form, FormStateInterface $form_state): void {
     // @todo any validation needed?
   }
 
   /**
    * {@inheritdoc}
    */
-  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
     // @todo any submit handling needed?
   }
 

--- a/modules/localgov_elections_ons_twenty_three_wards/src/Plugin/BoundaryProvider/OnsTwentyThreeWards.php
+++ b/modules/localgov_elections_ons_twenty_three_wards/src/Plugin/BoundaryProvider/OnsTwentyThreeWards.php
@@ -62,7 +62,7 @@ class OnsTwentyThreeWards extends BoundaryProviderPluginBase implements Containe
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
     return new static(
         $configuration,
         $plugin_id,
@@ -107,21 +107,21 @@ class OnsTwentyThreeWards extends BoundaryProviderPluginBase implements Containe
   /**
    * {@inheritdoc}
    */
-  public function defaultConfiguration() {
+  public function defaultConfiguration(): array {
     return [];
   }
 
   /**
    * {@inheritdoc}
    */
-  public function isConfigurable() {
+  public function isConfigurable(): true {
     return TRUE;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
 
     $url = "https://geoportal.statistics.gov.uk/datasets/ons::local-authority-districts-april-2023-names-and-codes-in-the-uk/explore";
 
@@ -183,7 +183,7 @@ class OnsTwentyThreeWards extends BoundaryProviderPluginBase implements Containe
   /**
    * {@inheritdoc}
    */
-  public function createBoundaries(BoundarySourceInterface $entity, array $form_values) {
+  public function createBoundaries(BoundarySourceInterface $entity, array $form_values): void {
     $lad = $entity->getSettings()['lad'];
     $vals = array_keys(array_filter($form_values['plugin']['config']['options'], function ($item) {
       return $item !== 0;
@@ -216,7 +216,7 @@ class OnsTwentyThreeWards extends BoundaryProviderPluginBase implements Containe
   /**
    * {@inheritDoc}
    */
-  public function validateConfigurationForm(array &$form, FormStateInterface $form_state) {
+  public function validateConfigurationForm(array &$form, FormStateInterface $form_state): void {
     // Should be not null since we enforce on form.
     $lad = $form_state->getValue('lad');
     // @todo Unsure if we should expose this and the other URL.
@@ -235,7 +235,7 @@ class OnsTwentyThreeWards extends BoundaryProviderPluginBase implements Containe
   /**
    * {@inheritdoc}
    */
-  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
     // Nothing to do.
   }
 

--- a/modules/localgov_elections_social_post/localgov_elections_social_post.module
+++ b/modules/localgov_elections_social_post/localgov_elections_social_post.module
@@ -11,7 +11,7 @@ use Drupal\Core\Url;
 /**
  * Implements hook_form_BASE_FORM_ID_alter().
  */
-function localgov_elections_social_post_form_node_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+function localgov_elections_social_post_form_node_form_alter(&$form, FormStateInterface $form_state, $form_id): void {
   $node = $form_state->getFormObject()->getEntity();
   if ($node->bundle() == "localgov_area_vote") {
     $form['actions']['save_and_add_areas'] = $form['actions']['submit'];
@@ -24,7 +24,7 @@ function localgov_elections_social_post_form_node_form_alter(&$form, FormStateIn
 /**
  * Save and tweet submit function callback.
  */
-function localgov_elections_social_post_save_and_tweet($form, FormStateInterface $form_state) {
+function localgov_elections_social_post_save_and_tweet($form, FormStateInterface $form_state): void {
   \Drupal::request()->query->remove('destination');
   if ($node = $form_state->getFormObject()->getEntity()) {
     if ($id = $node?->id()) {

--- a/modules/localgov_elections_social_post/src/Form/AreaVoteSocialPostForm.php
+++ b/modules/localgov_elections_social_post/src/Form/AreaVoteSocialPostForm.php
@@ -126,7 +126,7 @@ class AreaVoteSocialPostForm extends FormBase {
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container) {
+  public static function create(ContainerInterface $container): static {
     return new static(
         $container->get('config.factory'),
         $container->get('social_post.user_manager'),
@@ -258,7 +258,7 @@ class AreaVoteSocialPostForm extends FormBase {
    * @return void
    *   Returns nothing.
    */
-  public function edit($form, FormStateInterface $form_state) {
+  public function edit($form, FormStateInterface $form_state): void {
     $form_state->set('preview', NULL);
     $data = $form_state->get('original_data');
     $form_state->setValue('account', $data['account']);
@@ -277,7 +277,7 @@ class AreaVoteSocialPostForm extends FormBase {
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
-  public function preview($form, FormStateInterface $form_state) {
+  public function preview($form, FormStateInterface $form_state): void {
     $message = $this->getTokenizedMessage($form, $form_state);
     $form_state->set('preview', $message);
     $form_state->set('original_data', [
@@ -314,7 +314,7 @@ class AreaVoteSocialPostForm extends FormBase {
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
-  protected function getTokenizedMessage($form, FormStateInterface $form_state) {
+  protected function getTokenizedMessage($form, FormStateInterface $form_state): string {
     $message = $form_state->getValue('message');
     $user = $this->entityTypeManager->getStorage('user')->load($this->currentUser->id());
     return $this->tokenService->replace($message,
@@ -360,7 +360,7 @@ class AreaVoteSocialPostForm extends FormBase {
    * @return array
    *   An array of accounts.
    */
-  protected function getTwitterAccounts() {
+  protected function getTwitterAccounts(): array {
     $return_array = [];
     $accounts = $this->userManager->getAccounts('social_post_twitter');
     foreach ($accounts as $acc) {

--- a/modules/localgov_elections_uk_parties/localgov_elections_uk_parties.install
+++ b/modules/localgov_elections_uk_parties/localgov_elections_uk_parties.install
@@ -10,7 +10,7 @@ use Drupal\taxonomy\Entity\Term;
 /**
  * Implements hook_install().
  */
-function localgov_elections_uk_parties_install() {
+function localgov_elections_uk_parties_install(): void {
 
   $parties_vocabulary = 'localgov_party';
 

--- a/src/BoundaryPluginCollection.php
+++ b/src/BoundaryPluginCollection.php
@@ -45,7 +45,7 @@ class BoundaryPluginCollection extends DefaultSingleLazyPluginCollection {
   /**
    * {@inheritdoc}
    */
-  protected function initializePlugin($instance_id) {
+  protected function initializePlugin($instance_id): void {
     if (!$instance_id) {
       throw new PluginException("The boundary source '{$this->boundarySourceId}' did not specify a plugin.");
     }

--- a/src/BoundaryProviderInterface.php
+++ b/src/BoundaryProviderInterface.php
@@ -20,7 +20,7 @@ interface BoundaryProviderInterface extends PluginInspectionInterface, Configura
    * @param BoundarySourceInterface $config_instance
    *   The boundary source configuration instance.
    */
-  public function setConfigInstance(BoundarySourceInterface $config_instance);
+  public function setConfigInstance(BoundarySourceInterface $config_instance): void;
 
   /**
    * Get the config instance.
@@ -50,6 +50,6 @@ interface BoundaryProviderInterface extends PluginInspectionInterface, Configura
    * @param array $form_values
    *   The form values which come from the boundary fetch submission.
    */
-  public function createBoundaries(BoundarySourceInterface $entity, array $form_values);
+  public function createBoundaries(BoundarySourceInterface $entity, array $form_values): void;
 
 }

--- a/src/BoundaryProviderPluginBase.php
+++ b/src/BoundaryProviderPluginBase.php
@@ -28,7 +28,7 @@ abstract class BoundaryProviderPluginBase extends PluginBase implements Boundary
   /**
    * {@inheritDoc}
    */
-  public function setConfigInstance(BoundarySourceInterface $config_instance) {
+  public function setConfigInstance(BoundarySourceInterface $config_instance): void {
     $this->configInstance = $config_instance;
   }
 
@@ -50,7 +50,7 @@ abstract class BoundaryProviderPluginBase extends PluginBase implements Boundary
   /**
    * {@inheritdoc}
    */
-  public function calculateDependencies() {
+  public function calculateDependencies(): array {
     // @todo should be done properly
     return [];
   }
@@ -58,14 +58,14 @@ abstract class BoundaryProviderPluginBase extends PluginBase implements Boundary
   /**
    * {@inheritDoc}
    */
-  public function getConfiguration() {
+  public function getConfiguration(): array {
     return $this->config;
   }
 
   /**
    * Set the configuration.
    */
-  public function setConfiguration(array $configuration) {
+  public function setConfiguration(array $configuration): void {
     $this->config = $configuration;
   }
 

--- a/src/Controller/BoundarySourceAddController.php
+++ b/src/Controller/BoundarySourceAddController.php
@@ -24,14 +24,14 @@ class BoundarySourceAddController extends ControllerBase {
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container) {
+  public static function create(ContainerInterface $container): static {
     return new static($container->get('entity_type.manager'));
   }
 
   /**
    * Controller callback.
    */
-  public function __invoke($plugin_id) {
+  public function __invoke($plugin_id): mixed {
     $entity = $this->entityTypeManager->getStorage('boundary_source')->create(['plugin' => $plugin_id]);
     return $this->entityFormBuilder()->getForm($entity);
   }

--- a/src/Form/BounaryProviderAddForm.php
+++ b/src/Form/BounaryProviderAddForm.php
@@ -34,7 +34,7 @@ class BounaryProviderAddForm extends FormBase {
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container) {
+  public static function create(ContainerInterface $container): static {
     return new static(
         $container->get('plugin.manager.boundary_provider')
     );
@@ -43,14 +43,14 @@ class BounaryProviderAddForm extends FormBase {
   /**
    * {@inheritDoc}
    */
-  public function getFormId() {
+  public function getFormId(): string {
     return 'localgov_elections_boundary_provider_add';
   }
 
   /**
    * {@inheritDoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state) {
+  public function buildForm(array $form, FormStateInterface $form_state): array {
 
     $providers = [];
     foreach ($this->pluginManager->getDefinitions() as $id => $definition) {
@@ -98,7 +98,7 @@ class BounaryProviderAddForm extends FormBase {
   /**
    * {@inheritDoc}
    */
-  public function validateForm(array &$form, FormStateInterface $form_state) {
+  public function validateForm(array &$form, FormStateInterface $form_state): void {
     parent::validateForm($form, $form_state);
     if (!$form_state->getValue('provider')) {
       $form_state->setErrorByName('provider', $this->t('You need to select a plugin provider before you can add one.'));
@@ -108,7 +108,7 @@ class BounaryProviderAddForm extends FormBase {
   /**
    * {@inheritDoc}
    */
-  public function submitForm(array &$form, FormStateInterface $form_state) {
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
     if ($form_state->getValue('provider')) {
       $form_state->setRedirect(
           'entity.boundary_source.add_form',

--- a/src/Form/BoundaryFetchForm.php
+++ b/src/Form/BoundaryFetchForm.php
@@ -79,7 +79,7 @@ final class BoundaryFetchForm extends FormBase {
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container) {
+  public static function create(ContainerInterface $container): static {
 
     return new static(
         $container->get('class_resolver'),
@@ -183,7 +183,7 @@ final class BoundaryFetchForm extends FormBase {
    * @return mixed
    *   The form.
    */
-  protected function getFormClassForPlugin($entity) {
+  protected function getFormClassForPlugin($entity): mixed {
     $plugin = $this->entities[$entity]->getPlugin();
     $definition = $plugin->getPluginDefinition();
 

--- a/src/Form/BoundarySourceForm.php
+++ b/src/Form/BoundarySourceForm.php
@@ -29,7 +29,7 @@ class BoundarySourceForm extends EntityForm {
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container) {
+  public static function create(ContainerInterface $container): static {
     return new static(
         $container->get('plugin_form.factory'),
         $container->get('entity_type.manager')
@@ -132,7 +132,7 @@ class BoundarySourceForm extends EntityForm {
   /**
    * Helper function, checks whether an EventSource configuration entity exists.
    */
-  public function exist($id) {
+  public function exist($id): bool {
     $entity = $this->entityTypeManager->getStorage('boundary_source')->getQuery()
       ->accessCheck(FALSE)
       ->condition('id', $id)
@@ -143,7 +143,7 @@ class BoundarySourceForm extends EntityForm {
   /**
    * {@inheritdoc}
    */
-  public function validateForm(array &$form, FormStateInterface $form_state) {
+  public function validateForm(array &$form, FormStateInterface $form_state): void {
     $plugin = $this->getEntity()->getPlugin();
     if (!is_subclass_of($plugin, BoundaryProviderPluginBase::class)) {
       $form_state->setErrorByName('', "Plugin not subclass of BoundaryProviderPluginBase");
@@ -156,7 +156,7 @@ class BoundarySourceForm extends EntityForm {
   /**
    * {@inheritdoc}
    */
-  public function submitForm(array &$form, FormStateInterface $form_state) {
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
     parent::submitForm($form, $form_state);
     $this->getPluginForm($this->entity->getPlugin())->submitConfigurationForm($form['settings'], SubformState::createForSubform($form['settings'], $form, $form_state));
   }

--- a/src/Plugin/views/field/ElectionMajority.php
+++ b/src/Plugin/views/field/ElectionMajority.php
@@ -16,7 +16,7 @@ class ElectionMajority extends FieldPluginBase {
   /**
    * Leave empty to avoid a query on this field.
    */
-  public function query() {
+  public function query(): void {
 
   }
 
@@ -28,7 +28,7 @@ class ElectionMajority extends FieldPluginBase {
    *
    * @{inheritdoc}
    */
-  public function render(ResultRow $values) {
+  public function render(ResultRow $values): ?float {
     // Get ID of current election node (from URL argument)
     $node = \Drupal::routeMatch()->getParameter('node');
     $majority = NULL;

--- a/src/Plugin/views/field/ElectionSeatsParty.php
+++ b/src/Plugin/views/field/ElectionSeatsParty.php
@@ -18,7 +18,7 @@ class ElectionSeatsParty extends FieldPluginBase {
   /**
    * Leave empty to avoid a query on this field.
    */
-  public function query() {
+  public function query(): void {
 
   }
 
@@ -30,7 +30,7 @@ class ElectionSeatsParty extends FieldPluginBase {
    *
    * @{inheritdoc}
    */
-  public function render(ResultRow $values) {
+  public function render(ResultRow $values): ?int {
     $party = $values->_entity;
     $party_tid = $party->id();
     $seats = 0;

--- a/src/Plugin/views/field/ElectionShare.php
+++ b/src/Plugin/views/field/ElectionShare.php
@@ -17,7 +17,7 @@ class ElectionShare extends FieldPluginBase {
   /**
    * Leave empty to avoid a query on this field.
    */
-  public function query() {
+  public function query(): void {
 
   }
 
@@ -28,7 +28,7 @@ class ElectionShare extends FieldPluginBase {
    *
    * @{inheritdoc}
    */
-  public function render(ResultRow $values) {
+  public function render(ResultRow $values): ?float {
     // Get value of Area/Division vote (localgov_area_vote) from View -
     // unfortunately cannot use this Node directly due to way Views handles
     // aggregate functions from Custom fields.

--- a/src/Plugin/views/field/ElectionTurnout.php
+++ b/src/Plugin/views/field/ElectionTurnout.php
@@ -16,7 +16,7 @@ class ElectionTurnout extends FieldPluginBase {
   /**
    * Leave empty to avoid a query on this field.
    */
-  public function query() {
+  public function query():void {
 
   }
 
@@ -28,7 +28,7 @@ class ElectionTurnout extends FieldPluginBase {
    *
    * @{inheritdoc}
    */
-  public function render(ResultRow $values) {
+  public function render(ResultRow $values): string {
     $node = $values->_entity;
     $election = $node->id();
 

--- a/src/Plugin/views/field/PartyAbbr.php
+++ b/src/Plugin/views/field/PartyAbbr.php
@@ -15,7 +15,7 @@ class PartyAbbr extends FieldPluginBase {
   /**
    * Leave empty to avoid a query on this field.
    */
-  public function query() {
+  public function query(): void {
 
   }
 
@@ -24,7 +24,7 @@ class PartyAbbr extends FieldPluginBase {
    *
    * @{inheritdoc}
    */
-  public function render(ResultRow $values) {
+  public function render(ResultRow $values): string {
 
     // @todo Get rid
     return "IND";

--- a/src/Plugin/views/field/PartyName.php
+++ b/src/Plugin/views/field/PartyName.php
@@ -17,7 +17,7 @@ class PartyName extends FieldPluginBase {
   /**
    * Leave empty to avoid a query on this field.
    */
-  public function query() {
+  public function query():void {
 
   }
 
@@ -28,7 +28,7 @@ class PartyName extends FieldPluginBase {
    *
    * @{inheritdoc}
    */
-  public function render(ResultRow $values) {
+  public function render(ResultRow $values): mixed {
     $election = $values->_entity;
 
     // Iterate through each candidate and store votes.

--- a/src/Plugin/views/field/PartySeats.php
+++ b/src/Plugin/views/field/PartySeats.php
@@ -15,7 +15,7 @@ class PartySeats extends FieldPluginBase {
   /**
    * Leave empty to avoid a query on this field.
    */
-  public function query() {
+  public function query(): void {
 
   }
 
@@ -24,7 +24,7 @@ class PartySeats extends FieldPluginBase {
    *
    * @{inheritdoc}
    */
-  public function render(ResultRow $values) {
+  public function render(ResultRow $values): int {
 
     return 3;
   }

--- a/src/Plugin/views/field/WardCandidates.php
+++ b/src/Plugin/views/field/WardCandidates.php
@@ -17,7 +17,7 @@ class WardCandidates extends FieldPluginBase {
   /**
    * Leave empty to avoid a query on this field.
    */
-  public function query() {
+  public function query(): void {
 
   }
 
@@ -29,7 +29,7 @@ class WardCandidates extends FieldPluginBase {
    *
    * @{inheritdoc}
    */
-  public function render(ResultRow $values) {
+  public function render(ResultRow $values): array {
     $area_vote = $values->_entity;
     $hold_gain = $area_vote->get('localgov_election_hold_or_gain')->value;
     $markup = '<div class="ward-candidate-results">';

--- a/src/Plugin/views/field/WardCandidatesCandidate.php
+++ b/src/Plugin/views/field/WardCandidatesCandidate.php
@@ -17,7 +17,7 @@ class WardCandidatesCandidate extends FieldPluginBase {
   /**
    * Leave empty to avoid a query on this field.
    */
-  public function query() {
+  public function query(): void {
 
   }
 
@@ -29,7 +29,7 @@ class WardCandidatesCandidate extends FieldPluginBase {
    *
    * @{inheritdoc}
    */
-  public function render(ResultRow $values) {
+  public function render(ResultRow $values): array {
     $area_vote = $values->_entity;
     $markup = '<div class="ward-candidate-results">';
 

--- a/src/Plugin/views/field/WardCandidatesParty.php
+++ b/src/Plugin/views/field/WardCandidatesParty.php
@@ -17,7 +17,7 @@ class WardCandidatesParty extends FieldPluginBase {
   /**
    * Leave empty to avoid a query on this field.
    */
-  public function query() {
+  public function query(): void {
 
   }
 
@@ -29,7 +29,7 @@ class WardCandidatesParty extends FieldPluginBase {
    *
    * @{inheritdoc}
    */
-  public function render(ResultRow $values) {
+  public function render(ResultRow $values): array {
     $area_vote = $values->_entity;
     $hold_gain = $area_vote->get('localgov_election_hold_or_gain')->value;
     $markup = '<div class="ward-candidate-results">';

--- a/src/Plugin/views/field/WardCandidatesVotes.php
+++ b/src/Plugin/views/field/WardCandidatesVotes.php
@@ -17,7 +17,7 @@ class WardCandidatesVotes extends FieldPluginBase {
   /**
    * Leave empty to avoid a query on this field.
    */
-  public function query() {
+  public function query(): void {
 
   }
 
@@ -29,7 +29,7 @@ class WardCandidatesVotes extends FieldPluginBase {
    *
    * @{inheritdoc}
    */
-  public function render(ResultRow $values) {
+  public function render(ResultRow $values): array {
     $area_vote = $values->_entity;
     $markup = '<div class="ward-candidate-results">';
 

--- a/src/Plugin/views/field/WardMajority.php
+++ b/src/Plugin/views/field/WardMajority.php
@@ -15,7 +15,7 @@ class WardMajority extends FieldPluginBase {
   /**
    * Leave empty to avoid a query on this field.
    */
-  public function query() {
+  public function query(): void {
 
   }
 
@@ -27,7 +27,7 @@ class WardMajority extends FieldPluginBase {
    *
    * @{inheritdoc}
    */
-  public function render(ResultRow $values) {
+  public function render(ResultRow $values): mixed {
     $node = $values->_entity;
 
     // Iterate through each candidate and store votes.

--- a/src/Plugin/views/field/WardParty.php
+++ b/src/Plugin/views/field/WardParty.php
@@ -17,7 +17,7 @@ class WardParty extends FieldPluginBase {
   /**
    * Leave empty to avoid a query on this field.
    */
-  public function query() {
+  public function query(): void {
 
   }
 
@@ -28,7 +28,7 @@ class WardParty extends FieldPluginBase {
    *
    * @{inheritdoc}
    */
-  public function render(ResultRow $values) {
+  public function render(ResultRow $values): mixed {
     $node = $values->_entity;
 
     // Iterate through each candidate and store votes.

--- a/tests/src/Functional/ElectionAliasTest.php
+++ b/tests/src/Functional/ElectionAliasTest.php
@@ -183,7 +183,7 @@ final class ElectionAliasTest extends BrowserTestBase {
   /**
    * Test election sub-page aliases change after election alias changes.
    */
-  public function testSubPageAliasesChangeAfterElectionAliasChange() {
+  public function testSubPageAliasesChangeAfterElectionAliasChange(): void {
 
     // Get the current paths to compare later.
     $election_path = $this->election->toUrl()->toString();

--- a/tests/src/Functional/ElectionSummaryTest.php
+++ b/tests/src/Functional/ElectionSummaryTest.php
@@ -19,7 +19,7 @@ class ElectionSummaryTest extends BrowserTestBase {
   /**
    * Tests result heading text.
    */
-  public function testResultHeadingOnSummaryPage() {
+  public function testResultHeadingOnSummaryPage(): void {
 
     $election_page_url = $this->electionPage->toUrl();
 


### PR DESCRIPTION
Fixes PHP static analysis, ESLint yaml and Stylelink errors
https://github.com/localgovdrupal/localgov_elections/issues/156

Now passes Static Analysis, ESLint yaml and Stylelint checks.

Still failing on:
- ESLint javascript checks
- PHPUnit tests for D10, PHP8.1
- PHPUnit tests for D11 - not yet supported see D11 issue:  https://github.com/localgovdrupal/localgov_elections/issues/130

It works for me locally, but it will need someone to install and test including all sub-modules