### PR TITLE
Add LocalGov Elections Reporting - ONS Wards 2024 module

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,14 @@ The libraries required by Charts/Highcharts are included, by default via CDN. If
 
 You may also wish to use the submodules provided as part of the Localgov Election Reporting module. They are:
 
-1. LocalGov Elections Reporting ONS Wards 2023 - Boundary source provider for Office of National Statistics 2023 District Wards
-2. LocalGov Elections Reporting ONS Divisions 2024 - Boundary source provider for Office of National Statistics 2024 County Divisions
-3. LocalGov Elections Reporting ONS Parishes 2024 - Boundary source provider for Office of National Statistics 2024 Parishes
-4. Localgov Elections Parliamentary Constituency Provider - Boundary source provider for Office of National Statistics 2024 constituency boundaries
-5. LocalGov Elections Reporting Social Post Integration - Post results to social media (Twitter/X)
-6. LocalGov Elections Reporting Demo - Demo content to help with testing/evaluation
-7. LocalGov Elections Reporting - UK Parties - Adds the majority of UK political parties to the party taxonomy.
+1. LocalGov Elections Reporting ONS Wards 2023 - Boundary source provider for Office of National Statistics 2023 District Wards - **DEPRECIATED**
+2. LocalGov Elections Reporting ONS Wards 2023 - Boundary source provider for Office of National Statistics 2023 District Wards
+3. LocalGov Elections Reporting ONS Divisions 2024 - Boundary source provider for Office of National Statistics 2024 County Divisions
+4. LocalGov Elections Reporting ONS Parishes 2024 - Boundary source provider for Office of National Statistics 2024 Parishes
+5. Localgov Elections Parliamentary Constituency Provider - Boundary source provider for Office of National Statistics 2024 constituency boundaries
+6. LocalGov Elections Reporting Social Post Integration - Post results to social media (Twitter/X)
+7. LocalGov Elections Reporting Demo - Demo content to help with testing/evaluation
+8. LocalGov Elections Reporting - UK Parties - Adds the majority of UK political parties to the party taxonomy.
 
 Further details for these modules are in their own module READMEs and the [Documentation](docs/index.md).
 

--- a/modules/localgov_elections_ons_twenty_four_wards/README.md
+++ b/modules/localgov_elections_ons_twenty_four_wards/README.md
@@ -1,0 +1,33 @@
+# LocalGov Elections Reporting ONS Wards 2024 (Boundary Source Provider)
+
+A key part of the module is the idea of boundary source providers. Given that there are many different ways to classify
+election areas (wards, parishes, constituencies) and also change over time. This means we can't provide a one size fits
+all solution.
+
+See the [documentation](../../docs/index.md) for details on how to use this.
+
+## Data Sources
+
+The data for ONS Wards 2024 plugin is provided by the Office for National Statistics (ONS). The ONS provides various
+types of geo-data through their Open Geography Portal https://geoportal.statistics.gov.uk/. The datasets we use for the
+plugin are
+1. [Ward to LAD to County to County Electoral Division (May 2024) Lookup for EN](https://open-geography-portalx-ons.hub.arcgis.com/datasets/ons::ward-to-lad-to-county-to-county-electoral-division-may-2024-lookup-for-en/explore). This dataset provides data for English County Division codes and names and can be filtered by County and District.
+2. [Ward (December 2024) Boundaries EN BFE](https://geoportal.statistics.gov.uk/datasets/627ae9540e3a4e199f4594a727b35724_0/explore?showTable=true). This dataset provides the boundary data for English County Divisions.
+
+
+We also link to a different datasest in the plugin form which is used to help the user find the correct Local Authority
+District Code for when specifying their electoral area. This datasets is
+titled "[Local Authority Districts (December 2024) Names and Codes in the United Kingdom]('https://geoportal.statistics.gov.uk/datasets/ons::local-authority-districts-december-2024-names-and-codes-in-the-uk/explore)".
+
+## Boundary Fetching Process
+
+The boundary fetching process used by the ONS Wards 2024 Plugin is fairly simple and can be described in a few steps:
+
+1. Get the Local Authority District Code on the plugin configuration form. This limits the fetched boundaries to a
+   specific area. The plugin form validates the district code is valid, so you can't just enter anything here.
+2. The user press saves and a boundary source entity is saved with a reference to the plugin.
+3. The user is able to select the source entity from the boundary fetch form which is linked to from the election node.
+4. The plugin presents a subform which shows all the individual areas in the electoral district (specified by the
+   distrct code).
+5. The user selects the areas they want and then clicks submit. The areas are then downloaded to area vote nodes with
+   the boundary data attached.

--- a/modules/localgov_elections_ons_twenty_four_wards/localgov_elections_ons_twenty_four_wards.info.yml
+++ b/modules/localgov_elections_ons_twenty_four_wards/localgov_elections_ons_twenty_four_wards.info.yml
@@ -1,0 +1,8 @@
+name: LocalGov Elections Reporting - ONS Wards 2024
+description: ONS Wards 2024 Plugin
+type: module
+package: LocalGov Drupal
+core_version_requirement: ^9 || ^10
+
+dependencies:
+  - localgov_elections:localgov_elections

--- a/modules/localgov_elections_ons_twenty_four_wards/src/Form/OnsTwentyFourWardsDownloadForm.php
+++ b/modules/localgov_elections_ons_twenty_four_wards/src/Form/OnsTwentyFourWardsDownloadForm.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Drupal\localgov_elections_ons_twenty_four_wards\Form;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\localgov_elections\BoundaryProviderInterface;
+use Drupal\localgov_elections\Form\BoundaryProviderSubformInterface;
+use GuzzleHttp\Client;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Download form for ONS 2024 plugin.
+ */
+class OnsTwentyFourWardsDownloadForm implements BoundaryProviderSubformInterface, ContainerInjectionInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The plugin.
+   *
+   * @var \Drupal\localgov_elections\BoundaryProviderInterface
+   */
+  protected $plugin;
+
+  /**
+   * Value of the ARCGIS Services URL for the WD/LAD/CTY/CED lookup.
+   */
+  const URL_SERVICES_LU = 'https://services1.arcgis.com/ESMARspQHYMw9BZ9/arcgis/rest/services/WD24_LAD24_CTY24_CED24_EN_LU/FeatureServer/0/query';
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('http_client'),
+      $container->get('request_stack'),
+      $container->get('messenger')
+    );
+  }
+
+  /**
+   * Constructs the ONS 2024.
+   *
+   * @param \GuzzleHttp\Client $httpClient
+   *   Guzzle HTTP client.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request
+   *   The current request.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   Messenger service.
+   */
+  public function __construct(
+    protected Client $httpClient,
+    protected RequestStack $request,
+    protected MessengerInterface $messenger,
+  ) {}
+
+  /**
+   * {@inheritDoc}
+   */
+  public function setPlugin(BoundaryProviderInterface $plugin): void {
+    $this->plugin = $plugin;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPlugin(): BoundaryProviderInterface {
+    return $this->plugin;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $opts = $this->getAreasToDownload();
+    $form['options'] =
+      [
+        '#title' => $this->t('Areas to download'),
+        '#type' => 'tableselect',
+        '#header' => ['area' => $this->t('Area')],
+        '#options' => $opts,
+        '#required' => TRUE,
+      ];
+    return $form;
+  }
+
+  /**
+   * Fetch Wards.
+   *
+   * Fetches Ward Codes and Names from ONS API.
+   *
+   * @return array
+   *   Will return the array of data.
+   *   This will be empty if no Wards.
+   */
+  public function getAreasToDownload(): array {
+    $lad = $this->plugin->getConfiguration()['lad'];
+    $url = self::URL_SERVICES_LU;
+    $where = '';
+    $params = [];
+    $opts = [];
+    if (!$lad) {
+      return $opts;
+    }
+    $where = "LAD24CD = '$lad'";
+    $params = [
+      'query' => [
+        'where' => $where,
+        'outFields' => 'LAD24CD,LAD24NM,WD24NM,WD24CD',
+        'returnDistinctValues' => 'true',
+        'returnGeometry' => 'false',
+        'outSR' => '4326',
+        'f' => 'json',
+      ],
+    ];
+    try {
+      $response = $this->httpClient->get($url, $params);
+      if ($response->getStatusCode() == 200) {
+        $body = $response->getBody()->getContents();
+        $decoded = json_decode($body, TRUE);
+        foreach ($decoded['features'] as $item) {
+          $item = $item['attributes'];
+          $opts[$item['WD24CD']] = ['area' => $item['WD24NM']];
+        }
+      }
+      return $opts;
+    }
+    catch (\Exception $exception) {
+      $this->messenger->addError($this->t("Failed to get URL: @message",
+          ["@message" => $exception->getMessage()]));
+      return $opts;
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    // @todo any validation needed?
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    // @todo any submit handling needed?
+  }
+
+}

--- a/modules/localgov_elections_ons_twenty_four_wards/src/Plugin/BoundaryProvider/OnsTwentyFourWards.php
+++ b/modules/localgov_elections_ons_twenty_four_wards/src/Plugin/BoundaryProvider/OnsTwentyFourWards.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\localgov_elections_ons_twenty_four_Wards\Plugin\BoundaryProvider;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\localgov_elections\BoundaryProviderPluginBase;
+use Drupal\localgov_elections\BoundarySourceInterface;
+use Drupal\node\NodeInterface;
+use GuzzleHttp\Client;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Plugin implementation of the boundary_provider.
+ *
+ * @BoundaryProvider(
+ *   id = "localgov_elections_ons_2024_wards",
+ *   label = @Translation("ONS 2024 Wards"),
+ *   description = @Translation("ONS 2024 Wards."),
+ *   form = {
+ *     "download" = "Drupal\localgov_elections_ons_twenty_four_wards\Form\OnsTwentyFourWardsDownloadForm",
+ *   }
+ * )
+ */
+class OnsTwentyFourWards extends BoundaryProviderPluginBase implements ContainerFactoryPluginInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * Value of the ARCGIS Services URL for WD Boundaries.
+   */
+  const URL_SERVICES_WD = 'https://services1.arcgis.com/ESMARspQHYMw9BZ9/arcgis/rest/services/Wards_December_2024_Boundaries_UK_BFE/FeatureServer/0/query';
+
+  /**
+   * Value of the ARCGIS Services URL for the LAD lookup.
+   */
+  const URL_SERVICES_LU = 'https://services1.arcgis.com/ESMARspQHYMw9BZ9/arcgis/rest/services/LAD_DEC_2024_UK_NC/FeatureServer/0/query';
+
+  /**
+   * Value of the URL for the LAD lookup.
+   */
+  const URL_LAD = 'https://geoportal.statistics.gov.uk/datasets/ons::local-authority-districts-december-2024-names-and-codes-in-the-uk/explore';
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    return new static(
+        $configuration,
+        $plugin_id,
+        $plugin_definition,
+        $container->get('http_client'),
+        $container->get('entity_type.manager'),
+        $container->get('messenger')
+    );
+  }
+
+  /**
+   * Constructs an instance of the ONS 2024 Wards plugin.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin ID for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \GuzzleHttp\Client $httpClient
+   *   Http client.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   Entity type manager service.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   Messenger service.
+   */
+  public function __construct(
+    $configuration,
+    $plugin_id,
+    $plugin_definition,
+    protected Client $httpClient,
+    protected entityTypeManagerInterface $entityTypeManager,
+    protected MessengerInterface $messenger,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isConfigurable(): true {
+    return TRUE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+
+    $form['lad'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Local Authority District Code (LAD24CD)'),
+      '#maxlength' => 1000,
+      '#default_value' => $this->configuration['lad'] ?? "",
+      '#description' => $this->t('Local Authority District code. You can find this <a href="@url">here</a>. Use the value from the LAD24CD column.', ['@url' => self::URL_LAD]),
+      '#required' => FALSE,
+    ];
+
+    return $form;
+  }
+
+  /**
+   * Fetches boundary information from Local Authority IDs.
+   * 
+   * @param string $lad
+   *   An array of IDs to check against the GIS API.
+   *
+   * @param array $ids
+   *   An array of IDs to check against the GIS API.
+   *
+   * @return array
+   *   The matched features. Potentially empty if no IDs match.
+   *
+   * @throws \GuzzleHttp\Exception\GuzzleException
+   *   Could potentially throw a GuzzleException.
+   */
+  protected function fetchBoundaryInformation(string $lad, array $ids): array {
+    $gis_url = self::URL_SERVICES_WD;
+    $params = [
+      'query' => [
+        'where' => "LAD24CD = '$lad'",
+        'outFields' => '*',
+        'returnDistinctValues' => 'true',
+        'returnGeometry' => 'true',
+        'outSR' => '4326',
+        'f' => 'geojson',
+      ],
+    ];
+    $matched_features = [];
+    try {
+      $response = $this->httpClient->get($gis_url, $params);
+      if ($response->getStatusCode() == 200) {
+        $body = $response->getBody()->getContents();
+
+        $json_decoded = json_decode($body, TRUE);
+        $num_to_match = count($ids);
+        $num_matched = 0;
+        foreach ($json_decoded['features'] as $feature) {
+          if (in_array($feature['properties']['WD24CD'], $ids, TRUE)) {
+            $matched_features[] = $feature;
+            $num_matched++;
+          }
+          if ($num_matched >= $num_to_match) {
+            break;
+          }
+        }
+      }
+      return $matched_features;
+    }
+    catch (\Exception $exception) {
+      $this->messenger->addError($this->t("Failed to get URL: @message",
+          ["@message" => $exception->getMessage()]));
+      return $matched_features;
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createBoundaries(BoundarySourceInterface $entity, array $form_values): void {
+    $lad = $entity->getSettings()['lad'];
+    $vals = array_keys(array_filter($form_values['plugin']['config']['options'], function ($item) {
+      return $item !== 0;
+    }));
+
+    $boundaries = $this->fetchBoundaryInformation($lad, $vals);
+    $election = $form_values['localgov_election'];
+    $election_node = $this->entityTypeManager->getStorage('node')->load($election);
+    if ($election_node instanceof NodeInterface) {
+      $n_areas = 0;
+      foreach ($boundaries as $boundary) {
+        /** @var \Drupal\paragraphs\Entity\Paragraph $area_paragraph */
+        $name = $boundary['properties']['WD24NM'];
+        $area = $this->entityTypeManager->getStorage('node')->create(
+          [
+            'type' => 'localgov_area_vote',
+            'localgov_election_area_name' => $name,
+            'localgov_election_boundary_data' => json_encode($boundary),
+            'localgov_election' => ['target_id' => $election],
+            'title' => $election_node->getTitle() . ' - ' . $name,
+          ]
+        );
+        $area->save();
+        $n_areas += 1;
+      }
+
+      if ($n_areas > 0) {
+        $this->messenger->addMessage($this->t('Created @n_area area votes records with boundary information', ['@n_area' => $n_areas]));
+      }
+    }
+    else {
+      $this->messenger->addError($this->t('Node is not an Election Content Type Node'));
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function validateConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    $lad = $form_state->getValue('lad');
+    $url = self::URL_SERVICES_LU;
+    $params = [];
+    $where = '';
+    if (!$lad) {
+      $form_state->setErrorByName('lad', $this->t('The area codes are empty. Please try again.'));
+    } 
+    else {
+      $where = "LAD24CD = '$lad'";
+    }
+    $params = [
+      'query' => [
+        'where' => $where,
+        'outFields' => '*',
+        'returnDistinctValues' => 'true',
+        'f' => 'json',
+      ],
+    ];
+    try {
+      $response = $this->httpClient->get($url, $params);
+      if ($response->getStatusCode() == 200) {
+        $body = $response->getBody()->getContents();
+        $json_decoded = json_decode($body, TRUE);
+        $features = $json_decoded['features'] ?? [];
+        if (count($features) == 0) {
+          $form_state->setErrorByName('lad', $this->t('The area codes, @code, you inputted do not seem to come back as valid. Are you sure they are correct? Check that they are correct and try again.', ['@code' => $lad]));
+        }
+      }
+    }
+    catch (\Exception $exception) {
+      $this->messenger->addError($this->t("Failed to get URL: @message",
+          ["@message" => $exception->getMessage()]));
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    // Nothing to do.
+  }
+
+}

--- a/modules/localgov_elections_ons_twenty_three_wards/README.md
+++ b/modules/localgov_elections_ons_twenty_three_wards/README.md
@@ -1,4 +1,5 @@
 # LocalGov Elections Reporting ONS Wards 2023 (Boundary Source Provider)
+## NOTE: This is **Depreciated** for all new installs use: LocalGov Elections Reporting ONS Wards 2024  
 
 A key part of the module is the idea of boundary source providers. Given that there are many different ways to classify
 election areas (wards, parishes, constituencies) and also change over time. This means we can't provide a one size fits

--- a/modules/localgov_elections_ons_twenty_three_wards/src/Plugin/BoundaryProvider/OnsTwentyThreeWards.php
+++ b/modules/localgov_elections_ons_twenty_three_wards/src/Plugin/BoundaryProvider/OnsTwentyThreeWards.php
@@ -160,7 +160,6 @@ class OnsTwentyThreeWards extends BoundaryProviderPluginBase implements Containe
     $gis_url = "https://services1.arcgis.com/ESMARspQHYMw9BZ9/arcgis/rest/services/WD_MAY_2023_UK_BFE/FeatureServer/0/query?where=LAD23CD%20%3D%20%27$lad%27&outFields=LAD23CD,LAD23NM,WD23NM,WD23NMW,WD23CD&returnGeometry=true&outSR=4326&f=geojson";
     $response = $this->httpClient->get($gis_url);
     $body = $response->getBody()->getContents();
-
     $json_decoded = json_decode($body, TRUE);
     $num_to_match = count($ids);
     $num_matched = 0;


### PR DESCRIPTION
## What does this change?

Resolves:  https://github.com/localgovdrupal/localgov_elections/issues/155

1. Sub-module created to add a new Boundary Source Provider for Wards, new sub-module using [Ward to LAD to County to County Electoral Division (May 2024) Lookup for EN](https://open-geography-portalx-ons.hub.arcgis.com/datasets/ons::ward-to-lad-to-county-to-county-electoral-division-may-2024-lookup-for-en/explore) and [Ward (December 2024) Boundaries EN BFE](https://geoportal.statistics.gov.uk/datasets/627ae9540e3a4e199f4594a727b35724_0/explore?showTable=true)
2. Marks the `LocalGov Elections Reporting - ONS Wards 2023` as depreciated

## How to test

1. Enable sub-module
3. Navigate to Boundary Sources `/admin/structure/boundary-source`
4. Add a provider - select "ONS Wards 2024"
5. Enter valid District (LAD) Code and submit
6. Create a new election
7. Add areas - select newly created Boundary Source
8. Select some or all of the Parishes
9. Check new areas have been created with defined boundaries/maps

## How can we measure success?

- Wards can be created using the new 2024 data for District Council Elections