### PR TITLE
Fix for PHP 8.1

### DIFF
--- a/modules/localgov_elections_constituency_provider/src/Plugin/BoundaryProvider/UkConstituencyTwentyFourProvider.php
+++ b/modules/localgov_elections_constituency_provider/src/Plugin/BoundaryProvider/UkConstituencyTwentyFourProvider.php
@@ -113,7 +113,7 @@ class UkConstituencyTwentyFourProvider extends BoundaryProviderPluginBase implem
   /**
    * {@inheritdoc}
    */
-  public function isConfigurable(): true {
+  public function isConfigurable(): bool {
     return TRUE;
   }
 


### PR DESCRIPTION
Fixes #161
Fixes #160 

## What does this change?

Changes the return type of the ConstituencyTwentyFourProvider::isConfigurable() method from true to bool.

## How to test

The localgov_elections_constituency_provider module should install when running PHP 8.1. This is done in the tests.
